### PR TITLE
feat: Add CommandOrControl+T shortcut for new tab/window

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, globalShortcut } from "electron";
-import WindowManager from './window-manager.js';
+import WindowManager from "./window-manager.js";
 
 export function createActions(windowManager) {
   const actions = {
@@ -17,6 +17,14 @@ export function createActions(windowManager) {
       accelerator: "CommandOrControl+N",
       click: () => {
         windowManager.open();
+      },
+    },
+    NewTab: {
+      label: "New Tab",
+      accelerator: "CommandOrControl+T", // Changed to cross-platform
+      click: () => {
+        windowManager.open({ isMainWindow: false });
+        console.log("New tab/window opened via CommandOrControl+T");
       },
     },
     Forward: {
@@ -113,7 +121,7 @@ export function createActions(windowManager) {
                 if (input) {
                   input.focus();
                 }
-              }, 100); // Timeout to ensure the menu is visible and ready to receive focus
+              }, 100);
             }
           `);
         }
@@ -139,7 +147,6 @@ export function registerShortcuts(windowManager) {
     globalShortcut.unregister("CommandOrControl+F");
   };
 
-  // Register and unregister `Ctrl+F` based on focus
   app.on("browser-window-focus", (event, win) => {
     registerFindShortcut(win);
   });
@@ -148,15 +155,18 @@ export function registerShortcuts(windowManager) {
     unregisterFindShortcut();
   });
 
-  // Register remaining shortcuts
+  // Register remaining shortcuts with debug logging
   Object.keys(actions).forEach((key) => {
     const action = actions[key];
     if (key !== "FindInPage") {
-      // Register other shortcuts except `Ctrl+F`
-      globalShortcut.register(action.accelerator, () => {
+      const success = globalShortcut.register(action.accelerator, () => {
         const focusedWindow = BrowserWindow.getFocusedWindow();
-        if (focusedWindow) action.click(focusedWindow);
+        if (focusedWindow) {
+          action.click(focusedWindow);
+          console.log(`${action.label} triggered with ${action.accelerator}`);
+        }
       });
+      console.log(`Registering ${action.label} (${action.accelerator}): ${success ? "Success" : "Failed"}`);
     }
   });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { app, session, protocol as globalProtocol } from "electron";
+import { app, session, protocol as globalProtocol, globalShortcut } from "electron"; // Added globalShortcut
 import path from "path";
 import { fileURLToPath } from "url";
 import { createHandler as createIPFSHandler } from "./protocols/ipfs-handler.js";
@@ -12,6 +12,7 @@ import WindowManager from "./window-manager.js";
 import { attachContextMenus, setWindowManager } from "./context-menu.js";
 
 const __dirname = fileURLToPath(new URL("./", import.meta.url));
+
 
 const P2P_PROTOCOL = {
   standard: true,
@@ -86,11 +87,13 @@ app.on("before-quit", (event) => {
     .then(() => {
       console.log("Window states saved successfully.");
       windowManager.stopSaver();
+      globalShortcut.unregisterAll(); // Clean up all shortcuts on quit
       app.quit(); // Proceed to quit the app
     })
     .catch((error) => {
       console.error("Error saving window states on quit:", error);
       windowManager.stopSaver();
+      globalShortcut.unregisterAll(); // Clean up all shortcuts on quit
       app.quit(); // Proceed to quit the app even if saving fails
     });
 });


### PR DESCRIPTION
### What
Added a `CommandOrControl+T` shortcut to open a new window in `actions.js`.

### Why
Improves navigation across Mac, Windows, and Linux. Aligns with roadmap’s “Tabs?” item as a step toward tab support.

### How It Works
- Uses `windowManager.open({ isMainWindow: false })`.
- `Command+T` on Mac, `Ctrl+T` on Windows/Linux.

### Testing
1. Run `npm start`.
2. Press `Command+T` (Mac).
3. A new window opens, and terminal logs: “New tab/window opened via CommandOrControl+T”.

### Screenshots
- Terminal log: “New Tab triggered with CommandOrControl+T”