### PR TITLE
fix(upload): use raw file bytes for Hyper uploads to avoid multipart parsing error

### DIFF
--- a/src/pages/p2p/upload/index.html
+++ b/src/pages/p2p/upload/index.html
@@ -73,50 +73,65 @@ const protocolSelect = $('#protocolSelect')
 async function uploadFiles(files) {
     const protocol = protocolSelect.value;
 
-    const formData = new FormData();
-    // Append each file to the FormData
-    for (const file of files) {
-        formData.append('file', file, file.name);
-    }
-
-    // Construct the URL based on the protocol
-    let url;
     if (protocol === 'hyper') {
         const hyperdriveUrl = await generateHyperdriveKey('drag-and-drop');
-        url = `${hyperdriveUrl}`;
-    } else {
-        url = `ipfs://bafyaabakaieac/`;
-    }
+        console.log(`Hyper base URL: ${hyperdriveUrl}`);
 
-    try {
-        const response = await fetch(url, {
-            method: 'PUT',
-            body: formData,
-        });
+        for (const file of files) {
+            const url = `${hyperdriveUrl}${encodeURIComponent(file.name)}`;
+            console.log(`Uploading ${file.name} to ${url}`);
 
-        if (!response.ok) {
-            addError(files[0].name, await response.text());
-            return;
-        }
+            try {
+                const response = await fetch(url, {
+                    method: 'PUT',
+                    body: file, // Send raw file bytes
+                    headers: {
+                        'Content-Type': file.type || 'application/octet-stream'
+                    }
+                });
 
-        // For the hyper protocol, construct the file URLs
-        if (protocol === 'hyper') {
-            // Construct the file URLs for each uploaded file
-            for (const file of files) {
-                const fileUrl = `${url}${encodeURIComponent(file.name)}`;
-                addURL(fileUrl);
+                console.log(`Response for ${file.name}: ${response.status}, ok: ${response.ok}`);
+                if (!response.ok) {
+                    const errorText = await response.text();
+                    console.error(`Error uploading ${file.name}: ${errorText}`);
+                    addError(file.name, errorText);
+                    continue;
+                }
+
+                addURL(url);
+            } catch (error) {
+                console.error(`Error uploading ${file.name}:`, error);
+                addError(file.name, error.message);
             }
-        } else {
+        }
+    } else {
+        // Keep IPFS as FormData
+        const formData = new FormData();
+        for (const file of files) {
+            console.log(`Appending file for IPFS: ${file.name}`);
+            formData.append('file', file, file.name);
+        }
+        const url = `ipfs://bafyaabakaieac/`;
+        console.log(`Sending to IPFS: ${url}`);
+
+        try {
+            const response = await fetch(url, {
+                method: 'PUT',
+                body: formData,
+            });
+            console.log(`IPFS Response: ${response.status}`);
+            if (!response.ok) {
+                addError(files[0].name, await response.text());
+                return;
+            }
             const locationHeader = response.headers.get('Location');
             addURL(locationHeader);
+        } catch (error) {
+            console.error(`Error uploading to IPFS:`, error);
+            addError(files[0].name, error.message);
         }
-    } catch (error) {
-        console.error(`Error uploading ${files}:`, error);
-        addError(files[0].name, error.message);
     }
 }
-
-
 
 async function generateHyperdriveKey(name) {
     try {


### PR DESCRIPTION
```
Error in sup.gif: TypeError: Cannot read properties of undefined (reading 'toLowerCase') at Busboy. (node:internal/deps/undici/undici:5210:53) at Busboy.emit (node:events:514:28) at Busboy.emit (node:internal/deps/undici/undici:4260:37) at PartStream. (node:internal/deps/undici/undici:3709:17) at PartStream.emit (node:events:514:28) at HeaderParser. (node:internal/deps/undici/undici:2605:20) at HeaderParser.emit (node:events:514:28) at HeaderParser._finish (node:internal/deps/undici/undici:2524:12) at SBMH. (node:internal/deps/undici/undici:2495:16) at SBMH.emit (node:events:514:28)
```

- The TypeError occurred because `hypercore-fetch` (using `undici`) couldn’t parse the flattened `multipart/form-data` stream from `FormData`. Sending raw bytes avoids multipart parsing entirely.
- File-by-file `PUT` requests align with Hyperdrive’s file-based model.
- `Content-Type` headers ensure correct file type handling.

### Protocol-Specific Handling: 
The commit preserves distinct logic for Hyper (raw bytes) and IPFS (FormData), matching their different architectures.