### PR TITLE
fix: use menu accelerator for shortcuts to prevent shortcut-hijacking on linux/windows

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, globalShortcut } from "electron";
+import { app, BrowserWindow } from "electron";
 import WindowManager from './window-manager.js';
 
 export function createActions(windowManager) {
@@ -6,7 +6,8 @@ export function createActions(windowManager) {
     OpenDevTools: {
       label: "Open Dev Tools",
       accelerator: "CommandOrControl+Shift+I",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.openDevTools({ mode: "detach" });
         }
@@ -35,7 +36,8 @@ export function createActions(windowManager) {
     NewTab: {
       label: "New Tab",
       accelerator: "CommandOrControl+T",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.executeJavaScript(`{
             const tabBar = document.querySelector('#tabbar');
@@ -57,7 +59,8 @@ export function createActions(windowManager) {
     Forward: {
       label: "Forward",
       accelerator: "CommandOrControl+]",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.executeJavaScript(`{
             const tabBar = document.querySelector('#tabbar');
@@ -77,7 +80,8 @@ export function createActions(windowManager) {
     Back: {
       label: "Back",
       accelerator: "CommandOrControl+[",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.executeJavaScript(`{
             const tabBar = document.querySelector('#tabbar');
@@ -97,7 +101,8 @@ export function createActions(windowManager) {
     FocusURLBar: {
       label: "Focus URL Bar",
       accelerator: "CommandOrControl+L",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.executeJavaScript(`
             function focusUrlBar() {
@@ -129,7 +134,8 @@ export function createActions(windowManager) {
     Reload: {
       label: "Reload",
       accelerator: "CommandOrControl+R",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.executeJavaScript(`{
             const tabBar = document.querySelector('#tabbar');
@@ -169,7 +175,8 @@ export function createActions(windowManager) {
     Minimize: {
       label: "Minimize",
       accelerator: "CommandOrControl+M",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.minimize();
         }
@@ -178,7 +185,8 @@ export function createActions(windowManager) {
     Close: {
       label: "Close",
       accelerator: "CommandOrControl+W",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.executeJavaScript(`
             try {
@@ -204,7 +212,8 @@ export function createActions(windowManager) {
     FullScreen: {
       label: "Toggle Full Screen",
       accelerator: "F11",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
         }
@@ -213,7 +222,8 @@ export function createActions(windowManager) {
     FindInPage: {
       label: "Find in Page",
       accelerator: "CommandOrControl+F",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.executeJavaScript(`
             var findMenu = document.querySelector('find-menu');
@@ -233,7 +243,8 @@ export function createActions(windowManager) {
     CloseTab: {
       label: "Close Tab",
       accelerator: "CommandOrControl+Shift+W",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.executeJavaScript(`
             try {
@@ -258,7 +269,8 @@ export function createActions(windowManager) {
       accelerator: process.platform === "darwin"
     ? "CommandOrControl+Option+Right"
     : "CommandOrControl+Tab",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.executeJavaScript(`
             try {
@@ -284,7 +296,8 @@ export function createActions(windowManager) {
       accelerator: process.platform === "darwin"
     ? "CommandOrControl+Option+Left"
     : "CommandOrControl+Shift+Tab",
-      click: (focusedWindow) => {
+      click: () => {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {
           focusedWindow.webContents.executeJavaScript(`
             try {
@@ -310,39 +323,121 @@ export function createActions(windowManager) {
   return actions;
 }
 
-export function registerShortcuts(windowManager) {
-  const actions = createActions(windowManager);
+export function createMenuTemplate(windowManager) {
+    const actions = createActions(windowManager);
+    
+    const isMac = process.platform === 'darwin';
 
-  const registerFindShortcut = (focusedWindow) => {
-    if (focusedWindow) {
-      globalShortcut.register("CommandOrControl+F", () => {
-        actions.FindInPage.click(focusedWindow);
-      });
-    }
-  };
+    const template = [
+        // { role: 'appMenu' }
+        ...(isMac ? [{
+            label: app.name,
+            submenu: [
+                { role: 'about' },
+                { type: 'separator' },
+                { role: 'services' },
+                { type: 'separator' },
+                { role: 'hide' },
+                { role: 'hideOthers' },
+                { role: 'unhide' },
+                { type: 'separator' },
+                { role: 'quit' }
+            ]
+        }] : []),
+        // { role: 'fileMenu' }
+        {
+            label: 'File',
+            submenu: [
+                {...actions.NewWindow},
+                {...actions.NewTab},
+                { type: 'separator' },
+                {...actions.CloseTab},
+                {...actions.Close},
+                { type: 'separator' },
+                isMac ? { role: 'close' } : { role: 'quit' }
+            ]
+        },
+        // { role: 'editMenu' }
+        {
+            label: 'Edit',
+            submenu: [
+                { role: 'undo' },
+                { role: 'redo' },
+                { type: 'separator' },
+                { role: 'cut' },
+                { role: 'copy' },
+                { role: 'paste' },
+                ...(isMac ? [
+                    { role: 'pasteAndMatchStyle' },
+                    { role: 'delete' },
+                    { role: 'selectAll' },
+                    { type: 'separator' },
+                    {
+                        label: 'Speech',
+                        submenu: [
+                            { role: 'startSpeaking' },
+                            { role: 'stopSpeaking' }
+                        ]
+                    }
+                ] : [
+                    { role: 'delete' },
+                    { type: 'separator' },
+                    { role: 'selectAll' }
+                ]),
+                { type: 'separator' },
+                {...actions.FindInPage}
+            ]
+        },
+        // { role: 'viewMenu' }
+        {
+            label: 'View',
+            submenu: [
+                {...actions.Reload},
+                { type: 'separator' },
+                {...actions.FullScreen},
+                {...actions.OpenDevTools}
+            ]
+        },
+        // { role: 'windowMenu' }
+        {
+            label: 'Window',
+            submenu: [
+                {...actions.Minimize},
+                {...actions.NextTab},
+                {...actions.PreviousTab},
+                ...(isMac ? [
+                    { type: 'separator' },
+                    { role: 'front' },
+                    { type: 'separator' },
+                    { role: 'window' }
+                ] : [
+                    {...actions.Close}
+                ])
+            ]
+        },
+        // { role: 'goMenu }
+        {
+            label: 'Go',
+            submenu: [
+                {...actions.Back},
+                {...actions.Forward},
+                { type: 'separator' },
+                {...actions.FocusURLBar}
+            ]
+        },
+        {
+            role: 'help',
+            submenu: [
+                {
+                    label: 'Learn More',
+                    click: async () => {
+                        const { shell } = require('electron');
+                        await shell.openExternal('https://peersky.xyz');
+                    }
+                }
+            ]
+        }
+    ];
 
-  const unregisterFindShortcut = () => {
-    globalShortcut.unregister("CommandOrControl+F");
-  };
-
-  // Register and unregister `Ctrl+F` based on focus
-  app.on("browser-window-focus", (event, win) => {
-    registerFindShortcut(win);
-  });
-
-  app.on("browser-window-blur", () => {
-    unregisterFindShortcut();
-  });
-
-  // Register remaining shortcuts
-  Object.keys(actions).forEach((key) => {
-    const action = actions[key];
-    if (key !== "FindInPage") {
-      // Register other shortcuts except `Ctrl+F`
-      globalShortcut.register(action.accelerator, () => {
-        const focusedWindow = BrowserWindow.getFocusedWindow();
-        if (focusedWindow) action.click(focusedWindow);
-      });
-    }
-  });
+    return template;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import { createHandler as createIPFSHandler } from "./protocols/ipfs-handler.js"
 import { createHandler as createHyperHandler } from "./protocols/hyper-handler.js";
 import { createHandler as createWeb3Handler } from "./protocols/web3-handler.js";
 import { ipfsOptions, hyperOptions } from "./protocols/config.js";
-import { registerShortcuts } from "./actions.js";
+import { createMenuTemplate } from "./actions.js";
 import WindowManager, { createIsolatedWindow } from "./window-manager.js";
 import settingsManager from "./settings-manager.js";
 import { attachContextMenus, setWindowManager } from "./context-menu.js";
@@ -55,7 +55,10 @@ app.whenReady().then(async () => {
     windowManager.open({ isMainWindow: true });
   }
 
-  registerShortcuts(windowManager); // Pass windowManager to registerShortcuts
+  // Register shortcuts from menu template (NOTE: all these shortcuts works on a window only if a window is in focus)
+  const menuTemplate = createMenuTemplate(windowManager);
+  const menu = Menu.buildFromTemplate(menuTemplate);
+  Menu.setApplicationMenu(menu);
 
   windowManager.startSaver();
 


### PR DESCRIPTION
## Related Issue 
Fixes a bug where application shortcuts were globally overriding shortcuts in other applications, particularly noticeable on Linux and windows.

Closes: #57 

---

### Describe the add-ons or changes you've made

This PR refactors the application's shortcut handling to fix a critical bug where shortcuts like `Ctrl+R` or `Ctrl+T` would not work in other applications when Peersky Browser was running.

**The Problem:**  
Shortcuts were implemented using Electron's `globalShortcut` API, which creates system-wide keyboard hooks. This is incorrect for in-app actions.

**The Solution:**
1. Removed all usage of `globalShortcut.register()` for in-app actions from `actions.js`.
2. Implemented a new `createMenuTemplate` function that defines a native application menu structure ("File", "Edit", "View", "Go", etc.).
3. All shortcuts are now defined as `accelerators` within this menu template.
4. Updated `main.js` to build and set this menu on startup. This uses the OS's native, focus-aware shortcut handling, which is the correct approach.

This change ensures that all keyboard shortcuts are only active when the application is in focus, resolving the conflict with other apps.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Code style update (formatting, local variables)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] This change requires a documentation update  

---

## How Has This Been Tested?

1. Launched the application on a Linux system.  
2. Opened another application alongside it (e.g., Chrome browser).  
3. Verified that all the shortcuts work without overriding or racing with other applications.  
4. Confirmed that there are no regressions and all shortcuts function as intended.  

---

## Checklist

- [x] My code follows the "contribution guidelines" of this project.  
- [x] I have performed a self-review of my own code.  
- [ ] I have commented my code, particularly wherever it was hard to understand.  
- [x] My changes generate no new warnings.  
- [ ] Any dependent changes have been merged and published in downstream modules.  
