### PR TITLE
 feat: add image copy & download context menu

### DIFF
--- a/src/context-menu.js
+++ b/src/context-menu.js
@@ -163,7 +163,7 @@ export function attachContextMenus(browserWindow, windowManager) {
         menu.append(
           new MenuItem({
             label: "Copy Image",
-            click: async () => {
+            click: () => {
               try {
                 // Use copyImageAt for best quality
                 const img = webContents.copyImageAt(params.x, params.y);


### PR DESCRIPTION
## Related Issue (if any)

Users want to quickly copy or download images directly from the browser, but our project did not have these options before.
This PR adds those missing features.

Closes: #62 

### Describe the add-ons or changes you've made

This PR introduces new context-menu options to enhance image interactions within the browser:

**New Features Added:**

- **Copy Image**
   Uses webContents.copyImageAt to copy the image directly to the clipboard.

- **Copy Image Address**
   Retrieves and copies the direct URL of the image.

- **Save Image As**
   Opens a custom save dialog and performs a controlled download for better user experience.

## Type of change

<!-- What sort of change have you made: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. Open the browser

2. Search for any image

3. Navigate to the Images section

4. Right-click an image to open the context-menu

5. Use:

- Copy Image

- Save Image As

- Copy Image Address

6. Verified all options work correctly and produce expected results

## Checklist:

- [x] My code follows the "contribution guidelines" of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.

## Video for confirmation


https://github.com/user-attachments/assets/0e1adce2-0c80-41ae-84f9-010642fc387a


