### PR TITLE
refactor: migrate deprecated protocol handlers to fetch-style API

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -205,7 +205,7 @@ async function setupProtocols(session) {
   app.setAsDefaultProtocolClient("magnet");
 
   const browserProtocolHandler = await createBrowserHandler();
-  sessionProtocol.registerStreamProtocol("peersky", browserProtocolHandler, BROWSER_PROTOCOL);
+  sessionProtocol.handle("peersky", browserProtocolHandler);
 
   const browserThemeHandler = await createBrowserThemeHandler();
   sessionProtocol.registerStreamProtocol("browser", browserThemeHandler, BROWSER_PROTOCOL);


### PR DESCRIPTION
## Related Issue

#124 


This PR migrates our deprecated `protocol.registerStreamProtocol()` API handlers to the modern `protocol.handle()` API utilizing standard Web `Response` objects, as recommended by the latest Electron standards. 

Because this touches the core routing logic for all protocols, I am migrating and testing **one protocol at a time** in isolated commits to ensure 100% stability and zero regressions.

**Current Progress:**
- [x] Migrated internal `peersky://` pages `src/protocols/peersky-protocol.js`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested locally by compiling the app and manually verifying the functionality of each migrated protocol in the browser. 
- For `peersky://`: Manually loaded `peersky://home` and `peersky://settings` to confirm streams are successfully converted to fetch Responses and the pages load.

## Checklist:
- [x] My code follows the "contribution guidelines" of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Migration Progress Checklists (WIP)

### Phase 1: Internal Protocols
- [x] Implement `protocol.handle` for `src/protocols/peersky-protocol.js`
- [ ] Implement `protocol.handle` for `src/protocols/theme-handler.js`

### Phase 2: Resource Protocols
- [ ] Implement `protocol.handle` for `src/protocols/file-handler.js`
- [ ] Implement `protocol.handle` for `src/protocols/web3-handler.js`
- [ ] Implement `protocol.handle` for `src/protocols/hs-handler.js`

### Phase 3: Peer-To-Peer Streams (Read/Write)
- [ ] Implement `protocol.handle` for `src/protocols/bittorrent-handler.js`
- [ ] Implement `protocol.handle` for `src/protocols/hyper-handler.js`
- [ ] Implement `protocol.handle` for `src/protocols/ipfs-handler.js`
