### PR TITLE
fix: add TTL to ENS content hash cache

### DIFF
--- a/src/protocols/config.js
+++ b/src/protocols/config.js
@@ -76,13 +76,26 @@ export const RPC_URL =
     ? targetChain.rpcUrls[0]
     : (console.error(`Could not find RPC URL for chain ${targetChainId}`), null);
 
+// ENS cache TTL: 1 hour (ENS contract TTL is typically 24h; use a conservative 1h)
+export const ENS_CACHE_TTL_MS = 60 * 60 * 1000;
+
 // Initialize or load ENS cache
+// Each entry is { value: string, timestamp: number }
 let ensCache = new Map();
 if (fs.existsSync(ENS_CACHE)) {
   try {
     const data = fs.readFileSync(ENS_CACHE, "utf-8");
     const parsedData = JSON.parse(data);
-    ensCache = new Map(parsedData);
+    // Migrate legacy entries (bare strings) to the new { value, timestamp } shape,
+    // setting timestamp to 0 so they are treated as immediately expired.
+    ensCache = new Map(
+      parsedData.map(([k, v]) => [
+        k,
+        typeof v === "object" && v !== null && "value" in v
+          ? v
+          : { value: v, timestamp: 0 },
+      ])
+    );
   } catch (error) {
     console.error("Failed to load ENS cache from file:", error);
   }

--- a/src/protocols/ipfs-handler.js
+++ b/src/protocols/ipfs-handler.js
@@ -13,7 +13,7 @@ import { base32 } from "multiformats/bases/base32";
 import { base36 } from "multiformats/bases/base36";
 import { base58btc } from "multiformats/bases/base58";
 import { peerIdFromString, peerIdFromCID } from "@libp2p/peer-id";
-import { ensCache, saveEnsCache, RPC_URL, ipfsOptions } from "./config.js";
+import { ensCache, saveEnsCache, ENS_CACHE_TTL_MS, RPC_URL, ipfsOptions } from "./config.js";
 import { JsonRpcProvider } from "ethers";
 
 // Create a combined multibase decoder to handle base32, base36, and base58btc
@@ -333,8 +333,11 @@ export async function createHandler(ipfsOptions, session) {
           throw new Error("No resolver found for ENS name " + ensName);
 
         let contentHashRaw;
-        if (ensCache.has(ensName)) {
-          contentHashRaw = ensCache.get(ensName);
+        const cached = ensCache.get(ensName);
+        const isFresh =
+          cached && Date.now() - cached.timestamp < ENS_CACHE_TTL_MS;
+        if (isFresh) {
+          contentHashRaw = cached.value;
           console.log(
             `[${new Date().toISOString()}] ENS cache hit for ${ensName}`
           );
@@ -343,7 +346,7 @@ export async function createHandler(ipfsOptions, session) {
           if (!contentHashRaw) {
             throw new Error("No content hash set for ENS name " + ensName);
           }
-          ensCache.set(ensName, contentHashRaw);
+          ensCache.set(ensName, { value: contentHashRaw, timestamp: Date.now() });
           saveEnsCache(); // Persist the updated cache
           console.log(
             `[${new Date().toISOString()}] ENS cache miss for ${ensName}, fetched contentHash.`


### PR DESCRIPTION
## Related Issue:

No related issue, discovered during code review of the ENS resolution path.

### Description

The ENS content hash cache stored bare strings with no expiry metadata, causing stale content to be served indefinitely — including across restarts. If an ENS owner updated their site, visitors would silently continue loading the old IPFS CID with no error or indication anything was wrong.

Added a 1-hour TTL to cache entries by wrapping stored values as `{ value, timestamp }` objects. On cache hit, elapsed time is checked against the TTL; stale entries trigger a fresh on-chain lookup. Old flat-string entries on disk are handled gracefully on first launch after the update so nothing breaks for existing users.

Changes are in `src/protocols/config.js` (cache entry shape) and `src/protocols/ipfs-handler.js` (TTL gate on read path).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually verified by visiting a .eth site, modifying the cached entry on disk to simulate a stale record, and confirming the handler performs a fresh lookup after TTL expiry. Also confirmed backward compatibility with existing flat-string cache files on disk.

## Checklist:
- [x] My code follows the "contribution guidelines" of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.