### PR TITLE
fix(ipfs-handler): decode raw upload filenames and restore ENS codec guard

### DIFF
--- a/src/protocols/ipfs-handler.js
+++ b/src/protocols/ipfs-handler.js
@@ -498,6 +498,8 @@ export async function createHandler(ipfsOptions, session) {
           ipfsPath = [cid, ...urlParts];
         } else if (codec === "ipns-ns") {
           ipfsPath = await handleIPNSResolution(cidOrName, urlParts);
+        } else {
+          throw new Error("Unsupported content hash codec: " + codec);
         }
       } catch (e) {
         console.error("Failed to resolve ENS name:", e);


### PR DESCRIPTION
## Related Issue (if any)

Closes: #16

### Describe the add-ons or changes you've made

This PR fixes two issues in `ipfs-handler`:

1. Raw IPFS upload filename decoding  
For raw `PUT/POST` uploads, the filename extracted from URL pathname is now safely decoded before storing.  
This fixes the mismatch where `hello%20world.html` could be stored literally and later require double-encoded access.

2. ENS codec guard restoration  
Restored explicit fallback for unsupported ENS content hash codecs, so unsupported codecs fail early with a clear error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manual A/B verification with raw upload flow:

Test snippet:
```js
const name = "hello world.html";
const up = await fetch(`ipfs://bafyaabakaieac/${encodeURIComponent(name)}`, {
  method: "PUT",
  headers: { "Content-Type": "text/html" },
  body: "<h1>ok</h1>"
});
const root = up.headers.get("Location");

console.log("single", (await fetch(`${root}${encodeURIComponent(name)}`)).status);
console.log("double", (await fetch(`${root}${encodeURIComponent(encodeURIComponent(name))}`)).status);
```

Observed results:
- Before fix: `single = 500`, `double = 200`
- After fix: `single = 200`, `double = 500`

Also verified directory listing behavior:
- Before fix path could behave like encoded filename storage.
- After fix listing shows `hello world.html` and opens via `.../hello%20world.html` correctly.

## Checklist:

- [x] My code follows the "contribution guidelines" of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.

## Screenshots (Only for Front End and UI/UX Designers)

N/A (protocol/backend behavior change).