### PR TITLE
fix: dynamically position home screen icons when clock is disabled

### DIFF
--- a/src/pages/home.html
+++ b/src/pages/home.html
@@ -20,13 +20,17 @@
 </head>
 <body>
 <div class="home-background">
-  <simple-clock></simple-clock>
-  <a href="peersky://bookmarks" class="home-bookmarks">
-    <img src="peersky://static/assets/svg/bookmark-journal.svg" alt="Bookmarks">
-  </a>
-  <a href="peersky://settings/appearance" class="home-appearance">
-    <img src="peersky://static/assets/svg/sliders.svg" alt="Appearance">
-  </a>
+  <div class="top-right-controls">
+    <simple-clock></simple-clock>
+    <div class="top-icons">
+      <a href="peersky://settings/appearance" class="home-appearance">
+        <img src="peersky://static/assets/svg/sliders.svg" alt="Appearance">
+      </a>
+      <a href="peersky://bookmarks" class="home-bookmarks">
+        <img src="peersky://static/assets/svg/bookmark-journal.svg" alt="Bookmarks">
+      </a>
+    </div>
+  </div>
   <peer-bar></peer-bar>
 </div>
 

--- a/src/pages/theme/home.css
+++ b/src/pages/theme/home.css
@@ -109,10 +109,29 @@ body::before {
   opacity: 0.9;
 }
 
-.home-bookmarks {
+.top-right-controls {
   position: absolute;
-  top: 110px;
+  top: 20px;
   right: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 16px;
+  z-index: 3;
+}
+
+simple-clock {
+  position: static !important;
+  margin: 0 !important;
+}
+
+.top-icons {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+}
+
+.home-bookmarks {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -132,9 +151,6 @@ body::before {
 }
 
 .home-appearance {
-  position: absolute;
-  top: 110px;
-  right: 60px;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Related Issue (if any)
<!-- Info about the related issue -->
Closes:  <!-- Be sure to update this with the actual issue number if there is one -->
### Describe the add-ons or changes you've made
 Refactored the positioning of the top-right icons (Appearance slider and Bookmarks icon) and the `simple-clock` component into a dynamic flexbox container (`.top-right-controls`).
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## How Has This Been Tested?
- Verified that toggling the clock visibility in the settings allows the bookmarks and appearance icons to slide up seamlessly into the top right corner without any overlapping issues.
- Verified visual alignment across the home screen.
## Checklist:
- [x] My code follows the "contribution guidelines" of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
## Screenshots (Only for Front End and UI/UX Designers)
 Original           | Updated
 :--------------------: |:--------------------:
 [Original Screenshot] | [Updated Screenshot]