### PR TITLE
feat: Native Split View (Tab Tiling) Support

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -394,20 +394,6 @@ ipcMain.on("window-control", (_event, command) => {
   }
 });
 
-// IPC handler for moving tabs to new window
-ipcMain.on('new-window-with-tab', (_event, tabData) => {
-  // Create new window using WindowManager for proper persistence
-  windowManager.open({
-    url: tabData.url,
-    newWindow: true,
-    isolate: true,
-    singleTab: {
-      url: tabData.url,
-      title: tabData.title
-    }
-  });
-});
-
 // IPC handler for opening files in new tabs (used by BitTorrent pages)
 ipcMain.on('open-url-in-tab', (event, fileUrl) => {
   // Security: only allow file:// URLs

--- a/src/pages/static/assets/svg/layout-split.svg
+++ b/src/pages/static/assets/svg/layout-split.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-window-split" viewBox="0 0 16 16">
+  <path d="M2.5 4a.5.5 0 1 0 0-1 .5.5 0 0 0 0 1m2-.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0m1 .5a.5.5 0 1 0 0-1 .5.5 0 0 0 0 1"/>
+  <path d="M2 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2zm12 1a1 1 0 0 1 1 1v2H1V3a1 1 0 0 1 1-1zM1 13V6h6.5v8H2a1 1 0 0 1-1-1m7.5 1V6H15v7a1 1 0 0 1-1 1z"/>
+</svg>

--- a/src/pages/tab-bar.js
+++ b/src/pages/tab-bar.js
@@ -948,8 +948,12 @@ restoreTabs(persistedData) {
       // Close all extension popups when switching tabs
       try {
         const { ipcRenderer } = require('electron');
-        ipcRenderer.invoke('extensions-close-all-popups').catch(e => {});
-      } catch (error) {}
+        ipcRenderer.invoke('extensions-close-all-popups').catch(error => {
+          console.warn('[TabBar] Failed to close extension popups on tab switch:', error);
+        });
+      } catch (error) {
+        console.warn('[TabBar] Error closing extension popups:', error);
+      }
 
       const tab = this.tabs.find(t => t.id === tabId);
       if (tab) {

--- a/src/pages/tab-bar.js
+++ b/src/pages/tab-bar.js
@@ -888,8 +888,7 @@ restoreTabs(persistedData) {
     const leftId = this.pendingSplit.leftTabId;
     const rightId = tabId;
 
-    this.splitPairs.push({ leftTabId: leftId, rightTabId: rightId });
-
+    this.splitPairs.push({ leftTabId: leftId, rightTabId: rightId, splitRatio: 50 });
     this.pendingSplit = { isActive: false, leftTabId: null };
 
     const leftTab = document.getElementById(leftId);
@@ -973,12 +972,22 @@ restoreTabs(persistedData) {
   renderWebviews() {
     if (!this.webviewContainer) return;
 
-    // Reset all webviews
+    let divider = document.getElementById('split-view-divider');
+    if (!divider) {
+      divider = document.createElement('div');
+      divider.id = 'split-view-divider';
+      divider.className = 'split-view-divider';
+      divider.addEventListener('pointerdown', this.handleDividerPointerDown.bind(this));
+      this.webviewContainer.appendChild(divider);
+    }
+
+    divider.style.display = 'none';
     this.webviews.forEach((webview) => {
       webview.style.display = "none";
       webview.style.flex = "none";
       webview.style.width = "100%";
       webview.style.borderRight = "none";
+      webview.style.order = "";
     });
 
     const existingOverlay = document.getElementById('split-view-selector-overlay');
@@ -990,17 +999,19 @@ restoreTabs(persistedData) {
       const leftWv = this.webviews.get(activeSplit.leftTabId);
       const rightWv = this.webviews.get(activeSplit.rightTabId);
 
-      if (leftWv) {
+      if (leftWv && rightWv) {
         leftWv.style.display = "flex";
-        leftWv.style.flex = "0 0 50%";
-        leftWv.style.borderRight = "1px solid var(--settings-border)";
-      }
-      if (rightWv) {
+        leftWv.style.flex = `0 0 ${activeSplit.splitRatio || 50}%`;
+        leftWv.style.order = "1";
+        
+        divider.style.display = "block";
+        divider.style.order = "2";
+
         rightWv.style.display = "flex";
-        rightWv.style.flex = "0 0 50%";
+        rightWv.style.flex = `0 0 ${100 - (activeSplit.splitRatio || 50)}%`;
+        rightWv.style.order = "3";
       }
-    } 
-    else if (this.pendingSplit.isActive && this.activeTabId === this.pendingSplit.leftTabId) {
+    } else if (this.pendingSplit.isActive && this.activeTabId === this.pendingSplit.leftTabId) {
       const leftWv = this.webviews.get(this.pendingSplit.leftTabId);
       if (leftWv) {
         leftWv.style.display = "flex";
@@ -1008,8 +1019,7 @@ restoreTabs(persistedData) {
         leftWv.style.borderRight = "1px solid var(--settings-border)";
       }
       this.drawSplitSelectorOverlay();
-    } 
-    else {
+    } else {
       const activeWv = this.webviews.get(this.activeTabId);
       if (activeWv) {
         activeWv.style.display = "flex";
@@ -2718,6 +2728,68 @@ restoreTabs(persistedData) {
 
       this.draggedTab = null;
     }, 200);
+  }
+
+  // Split View Divider Drag Handlers
+
+  handleDividerPointerDown(e) {
+    e.preventDefault();
+
+    this.activeDividerSplit = this.getSplitForTab(this.activeTabId);
+    if (!this.activeDividerSplit) return;
+
+    this.isDraggingDivider = true;
+
+    if (this.webviewContainer) {
+      this.webviewContainer.style.pointerEvents = 'none';
+    }
+
+    const divider = document.getElementById('split-view-divider');
+    if (divider) divider.classList.add('dragging');
+
+    this.onDividerMove = this.handleDividerPointerMove.bind(this);
+    this.onDividerUp = this.handleDividerPointerUp.bind(this);
+
+    window.addEventListener('pointermove', this.onDividerMove);
+    window.addEventListener('pointerup', this.onDividerUp);
+  }
+
+  handleDividerPointerMove(e) {
+    if (!this.isDraggingDivider || !this.activeDividerSplit) return;
+
+    const containerRect = this.webviewContainer.getBoundingClientRect();
+
+    let newRatio = ((e.clientX - containerRect.left) / containerRect.width) * 100;
+
+    newRatio = Math.max(10, Math.min(newRatio, 90));
+
+    // Update the state
+    this.activeDividerSplit.splitRatio = newRatio;
+
+    const leftWv = this.webviews.get(this.activeDividerSplit.leftTabId);
+    const rightWv = this.webviews.get(this.activeDividerSplit.rightTabId);
+
+    if (leftWv && rightWv) {
+      leftWv.style.flex = `0 0 ${newRatio}%`;
+      rightWv.style.flex = `0 0 ${100 - newRatio}%`;
+    }
+  }
+
+  handleDividerPointerUp(e) {
+    if (!this.isDraggingDivider) return;
+    this.isDraggingDivider = false;
+
+    const divider = document.getElementById('split-view-divider');
+    if (divider) divider.classList.remove('dragging');
+
+    if (this.webviewContainer) {
+      this.webviewContainer.style.pointerEvents = '';
+    }
+
+    window.removeEventListener('pointermove', this.onDividerMove);
+    window.removeEventListener('pointerup', this.onDividerUp);
+
+    this.saveTabsState(); 
   }
 
   // --- P2P Protocol Helpers ---

--- a/src/pages/tab-bar.js
+++ b/src/pages/tab-bar.js
@@ -1302,7 +1302,7 @@ restoreTabs(persistedData) {
       </div>
       ${isSplit ? `
         <div class="context-menu-item" data-action="separate-split">
-          <img class="menu-icon" src="${iconPath}/layout-split.svg" style="transform: rotate(90deg);" />
+          <img class="menu-icon" src="${iconPath}/layout-split.svg" />
           Separate split view
         </div>
         ` : `

--- a/src/pages/tab-bar.js
+++ b/src/pages/tab-bar.js
@@ -23,6 +23,11 @@ class TabBar extends HTMLElement {
     this.buildTabBar();
     this.setupBrowserCloseHandler();
     this.setupTabContextMenu();
+    this.splitPairs = [];
+    this.pendingSplit = {
+      isActive: false,
+      leftTabId: null
+    };
   }
 
   // Connect to the webview container where all webviews will live
@@ -776,12 +781,19 @@ restoreTabs(persistedData) {
         faviconElement.style.display = 'block';
       }
     });
+
+    webview.addEventListener("focus", () => {
+      if (this.activeTabId !== tabId) {
+        this.selectTab(tabId);
+      }
+    });
   }
 
   closeTab(tabId) {
     this.destroyHoverCard(); // remove lingering hover card
     const tabElement = document.getElementById(tabId);
     if (!tabElement) return;
+    this.breakSplitView(tabId);
 
     // Get index of tab to close
     const tabIndex = this.tabs.findIndex(tab => tab.id === tabId);
@@ -846,23 +858,89 @@ restoreTabs(persistedData) {
     this.dispatchEvent(new CustomEvent("tab-closed", { detail: { tabId } }));
   }
 
+  getSplitForTab(tabId) {
+    return this.splitPairs.find(split => split.leftTabId === tabId || split.rightTabId === tabId);
+  }
+
+  initiateSplitView(tabId) {
+    // Prevent splitting a tab that is already in a split
+    if (this.getSplitForTab(tabId)) return;
+
+    this.pendingSplit = {
+      isActive: true,
+      leftTabId: tabId
+    };
+
+    const leftTab = document.getElementById(tabId);
+    if (leftTab) leftTab.classList.add('split-pending');
+
+    if (this.webviewContainer) {
+      this.webviewContainer.style.display = 'flex';
+      this.webviewContainer.style.flexDirection = 'row';
+    }
+
+    this.selectTab(tabId);
+  }
+
+  assignRightSplitTab(tabId) {
+    if (!this.pendingSplit.isActive) return;
+
+    const leftId = this.pendingSplit.leftTabId;
+    const rightId = tabId;
+
+    this.splitPairs.push({ leftTabId: leftId, rightTabId: rightId });
+
+    this.pendingSplit = { isActive: false, leftTabId: null };
+
+    const leftTab = document.getElementById(leftId);
+    const rightTab = document.getElementById(rightId);
+
+    if (leftTab && rightTab && leftTab.parentNode) {
+      leftTab.classList.remove('split-pending');
+      leftTab.classList.add('split-left');
+
+      rightTab.classList.add('split-right');
+
+      leftTab.parentNode.insertBefore(rightTab, leftTab.nextSibling);
+    }
+
+    this.selectTab(rightId); 
+  }
+
+  breakSplitView(tabId) {
+    const splitIndex = this.splitPairs.findIndex(s => s.leftTabId === tabId || s.rightTabId === tabId);
+
+    if (splitIndex !== -1) {
+      const split = this.splitPairs[splitIndex];
+      const leftTab = document.getElementById(split.leftTabId);
+      const rightTab = document.getElementById(split.rightTabId);
+
+      if (leftTab) leftTab.classList.remove('split-left');
+      if (rightTab) rightTab.classList.remove('split-right');
+
+      this.splitPairs.splice(splitIndex, 1);
+
+      const survivingTabId = split.leftTabId === tabId ? split.rightTabId : split.leftTabId;
+      this.selectTab(survivingTabId);
+      return;
+    }
+
+    if (this.pendingSplit.isActive && this.pendingSplit.leftTabId === tabId) {
+      const leftTab = document.getElementById(this.pendingSplit.leftTabId);
+      if (leftTab) leftTab.classList.remove('split-pending');
+
+      this.pendingSplit = { isActive: false, leftTabId: null };
+      this.renderWebviews();
+    }
+  }
+
   // Update the selectTab method to handle display properly
   selectTab(tabId, isNewTab = false) {
-    
-    // First, hide ALL webviews to ensure clean state
-    this.webviews.forEach((webview) => {
-      webview.style.display = "none";
-    });
-    
-    // Remove active class from current active tab
     if (this.activeTabId) {
       const currentActive = document.getElementById(this.activeTabId);
-      if (currentActive) {
-        currentActive.classList.remove("active");
-      }
+      if (currentActive) currentActive.classList.remove("active");
     }
-    
-    // Add active class to new active tab
+
     const newActive = document.getElementById(tabId);
     if (newActive) {
       newActive.classList.add("active");
@@ -871,41 +949,154 @@ restoreTabs(persistedData) {
       // Close all extension popups when switching tabs
       try {
         const { ipcRenderer } = require('electron');
-        ipcRenderer.invoke('extensions-close-all-popups').catch(error => {
-          console.warn('[TabBar] Failed to close extension popups on tab switch:', error);
-        });
-      } catch (error) {
-        console.warn('[TabBar] Error closing extension popups:', error);
-      }
-      
-      // Show ONLY the newly active webview
-      const newWebview = this.webviews.get(tabId);
-      if (newWebview) {
-        newWebview.style.display = "flex";
-        
-        // Focus the webview after a short delay to ensure it's visible
-        // Skip webview focus for new tabs to allow address bar focus
-        if (!isNewTab) {
-          setTimeout(() => {
-            if (newWebview && document.body.contains(newWebview)) {
-              newWebview.focus();
-            }
-          }, 10);
-        }
-      }
-      
-      // Find the URL for this tab
+        ipcRenderer.invoke('extensions-close-all-popups').catch(e => {});
+      } catch (error) {}
+
       const tab = this.tabs.find(t => t.id === tabId);
       if (tab) {
-        // Dispatch event that tab was selected with the URL
-        this.dispatchEvent(new CustomEvent("tab-selected", { 
-          detail: { tabId, url: tab.url } 
-        }));
+        this.dispatchEvent(new CustomEvent("tab-selected", { detail: { tabId, url: tab.url } }));
       }
     }
-    
-    // Save state when tab is selected
+
+    this.renderWebviews();
+
+    if (!isNewTab) {
+      setTimeout(() => {
+        const activeWv = this.webviews.get(tabId);
+        if (activeWv && document.body.contains(activeWv)) activeWv.focus();
+      }, 10);
+    }
+
     this.saveTabsState();
+  }
+
+  renderWebviews() {
+    if (!this.webviewContainer) return;
+
+    // Reset all webviews
+    this.webviews.forEach((webview) => {
+      webview.style.display = "none";
+      webview.style.flex = "none";
+      webview.style.width = "100%";
+      webview.style.borderRight = "none";
+    });
+
+    const existingOverlay = document.getElementById('split-view-selector-overlay');
+    if (existingOverlay) existingOverlay.style.display = 'none';
+
+    const activeSplit = this.getSplitForTab(this.activeTabId);
+
+    if (activeSplit) {
+      const leftWv = this.webviews.get(activeSplit.leftTabId);
+      const rightWv = this.webviews.get(activeSplit.rightTabId);
+
+      if (leftWv) {
+        leftWv.style.display = "flex";
+        leftWv.style.flex = "0 0 50%";
+        leftWv.style.borderRight = "1px solid var(--settings-border)";
+      }
+      if (rightWv) {
+        rightWv.style.display = "flex";
+        rightWv.style.flex = "0 0 50%";
+      }
+    } 
+    else if (this.pendingSplit.isActive && this.activeTabId === this.pendingSplit.leftTabId) {
+      const leftWv = this.webviews.get(this.pendingSplit.leftTabId);
+      if (leftWv) {
+        leftWv.style.display = "flex";
+        leftWv.style.flex = "0 0 50%";
+        leftWv.style.borderRight = "1px solid var(--settings-border)";
+      }
+      this.drawSplitSelectorOverlay();
+    } 
+    else {
+      const activeWv = this.webviews.get(this.activeTabId);
+      if (activeWv) {
+        activeWv.style.display = "flex";
+        activeWv.style.flex = "1";
+      }
+    }
+  }
+
+  drawSplitSelectorOverlay() {
+    let selector = document.getElementById('split-view-selector-overlay');
+
+    if (!selector) {
+      selector = document.createElement('div');
+      selector.id = 'split-view-selector-overlay';
+      this.webviewContainer.appendChild(selector);
+    }
+
+    selector.style.display = 'flex';
+    Object.assign(selector.style, {
+      flex: '0 0 50%',
+      backgroundColor: 'var(--browser-theme-background)',
+      display: 'flex',
+      flexDirection: 'column',
+      padding: '30px',
+      boxSizing: 'border-box',
+      overflowY: 'auto',
+      color: 'var(--browser-theme-text-color)'
+    });
+
+    selector.innerHTML = `
+      <h2 style="margin-top: 0; font-weight: normal; font-size: 1.5rem;">Select a tab to split</h2>
+      <p style="color: var(--settings-text-secondary); margin-bottom: 20px;">Choose a tab to open in the right panel.</p>
+    `;
+
+    const newTabBtn = document.createElement('button');
+    Object.assign(newTabBtn.style, {
+      padding: '12px 16px',
+      marginBottom: '16px',
+      backgroundColor: 'var(--browser-theme-primary-highlight)',
+      color: '#fff',
+      border: 'none',
+      borderRadius: '8px',
+      cursor: 'pointer',
+      fontSize: '14px',
+      fontWeight: 'bold',
+      textAlign: 'left',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '8px'
+    });
+    newTabBtn.innerHTML = `<span style="font-size:18px;">+</span> Open New Tab`;
+    newTabBtn.onclick = () => {
+      const newTabId = this.addTab();
+      this.assignRightSplitTab(newTabId);
+    };
+    selector.appendChild(newTabBtn);
+
+    const tabsList = document.createElement('div');
+    tabsList.style.display = 'flex';
+    tabsList.style.flexDirection = 'column';
+    tabsList.style.gap = '8px';
+
+    this.tabs.forEach(tab => {
+      // Don't show tabs that are already in ANY split view, or the currently pending tab
+      if (tab.id !== this.pendingSplit.leftTabId && !this.getSplitForTab(tab.id)) {
+        const tabBtn = document.createElement('button');
+        Object.assign(tabBtn.style, {
+          padding: '12px 16px',
+          backgroundColor: 'var(--settings-card-bg)',
+          color: 'var(--browser-theme-text-color)',
+          border: '1px solid var(--settings-border)',
+          borderRadius: '8px',
+          cursor: 'pointer',
+          textAlign: 'left',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '12px',
+          fontSize: '14px'
+        });
+
+        tabBtn.innerHTML = `<img src="peersky://static/assets/icon16.png" style="width:16px; height:16px;"> ${tab.title}`;
+        tabBtn.onclick = () => this.assignRightSplitTab(tab.id);
+        tabsList.appendChild(tabBtn);
+      }
+    });
+
+    selector.appendChild(tabsList);
   }
 
   updateTab(tabId, { url, title }) {
@@ -1032,6 +1223,7 @@ restoreTabs(persistedData) {
     const webview = this.webviews.get(tabId);
     const isPinned = this.pinnedTabs.has(tabId);
     const isMuted = webview?.isAudioMuted() || false;
+    const isSplit = this.getSplitForTab(tabId) || (this.pendingSplit.isActive && this.pendingSplit.leftTabId === tabId);
 
     const iconPath = 'peersky://static/assets/svg';
 
@@ -1044,6 +1236,17 @@ restoreTabs(persistedData) {
         <img class="menu-icon" src="${iconPath}/copy.svg" />
         Duplicate tab
       </div>
+      ${isSplit ? `
+        <div class="context-menu-item" data-action="separate-split">
+          <img class="menu-icon" src="${iconPath}/layout-split.svg" style="transform: rotate(90deg);" />
+          Separate split view
+        </div>
+        ` : `
+        <div class="context-menu-item" data-action="split-view">
+          <img class="menu-icon" src="${iconPath}/layout-split.svg" />
+          Split view
+        </div>
+      `}
       <div class="context-menu-item" data-action="mute">
         <img class="menu-icon" src="${iconPath}/${isMuted ? 'volume-up.svg' : 'volume-mute.svg'}" />
         ${isMuted ? 'Unmute site' : 'Mute site'}
@@ -1157,6 +1360,14 @@ restoreTabs(persistedData) {
         this.duplicateTab(tabId);
         break;
         
+      case 'split-view':
+        this.initiateSplitView(tabId);
+        break;
+
+      case 'separate-split':
+        this.breakSplitView(tabId);
+        break;
+
       case 'mute':
         if (webview) {
           if (webview.isAudioMuted()) {

--- a/src/pages/tab-bar.js
+++ b/src/pages/tab-bar.js
@@ -236,6 +236,7 @@ getAllTabGroups() {
         }),
         activeTabId: this.activeTabId,
         tabCounter: this.tabCounter,
+        splitPairs: this.splitPairs,
         tabGroups: Array.from(this.tabGroups.entries()).map(([id, group]) => ({
           id,
           name: group.name,
@@ -345,6 +346,26 @@ restoreTabs(persistedData) {
       }
     }
   });
+
+  if (persistedData.splitPairs && persistedData.splitPairs.length > 0) {
+    this.splitPairs = persistedData.splitPairs;
+    
+    setTimeout(() => {
+      this.splitPairs.forEach(split => {
+        const leftTab = document.getElementById(split.leftTabId);
+        const rightTab = document.getElementById(split.rightTabId);
+
+        if (leftTab && rightTab) {
+          leftTab.classList.add('split-left');
+          rightTab.classList.add('split-right');
+          
+          if (leftTab.nextSibling !== rightTab) {
+            leftTab.parentNode.insertBefore(rightTab, leftTab.nextSibling);
+          }
+        }
+      });
+    }, 0);
+  }
 
   // Render all group headers
   for (const groupId of this.tabGroups.keys()) {

--- a/src/pages/tab-bar.js
+++ b/src/pages/tab-bar.js
@@ -138,6 +138,35 @@ class TabBar extends HTMLElement {
     const singleTabUrl = searchParams.get('singleTabUrl');
     const singleTabTitle = searchParams.get('singleTabTitle');
     
+    const splitLeftUrl = searchParams.get('splitLeftUrl');
+    const splitRightUrl = searchParams.get('splitRightUrl');
+
+    if (isIsolated && splitLeftUrl && splitRightUrl) {
+      const leftTitle = searchParams.get('splitLeftTitle') || "New Tab";
+      const rightTitle = searchParams.get('splitRightTitle') || "New Tab";
+      const ratio = parseInt(searchParams.get('splitRatio') || '50', 10);
+
+      const leftTabId = this.addTab(splitLeftUrl, leftTitle);
+      const rightTabId = this.addTab(splitRightUrl, rightTitle);
+
+      this.splitPairs.push({ leftTabId: leftTabId, rightTabId: rightTabId, splitRatio: ratio });
+      
+      const leftTab = document.getElementById(leftTabId);
+      const rightTab = document.getElementById(rightTabId);
+      
+      if (leftTab && rightTab && leftTab.parentNode) {
+        leftTab.classList.add('split-left');
+        rightTab.classList.add('split-right');
+        
+        if (leftTab.nextSibling !== rightTab) {
+          leftTab.parentNode.insertBefore(rightTab, leftTab.nextSibling);
+        }
+      }
+      
+      this.selectTab(rightTabId);
+      return;
+    }
+
     if (isIsolated && (singleTabUrl || initialUrl)) {
       // For isolated windows, ONLY create the specified tab and don't load any persisted tabs
       const tabUrl = singleTabUrl || initialUrl;
@@ -1494,6 +1523,56 @@ restoreTabs(persistedData) {
     return newTabId;
   }
 
+  moveSplitGroupToNewWindow(tabIds) {
+    const [leftId, rightId] = tabIds;
+    
+    const leftTab = this.tabs.find(t => t.id === leftId);
+    const rightTab = this.tabs.find(t => t.id === rightId);
+    const splitPair = this.splitPairs.find(s => s.leftTabId === leftId && s.rightTabId === rightId);
+    const splitRatio = splitPair ? splitPair.splitRatio : 50;
+
+    if (!leftTab || !rightTab) return;
+
+    tabIds.forEach(tabId => {
+      this.destroyHoverCard();
+      const tabElement = document.getElementById(tabId);
+      if (tabElement) tabElement.remove();
+
+      const tabIndex = this.tabs.findIndex(t => t.id === tabId);
+      if (tabIndex !== -1) this.tabs.splice(tabIndex, 1);
+
+      const webview = this.webviews.get(tabId);
+      if (webview) {
+        webview.remove();
+        this.webviews.delete(tabId);
+      }
+
+      this.pinnedTabs.delete(tabId);
+      this.removeTabFromGroup(tabId);
+    });
+
+    const splitIndex = this.splitPairs.findIndex(s => s.leftTabId === leftId && s.rightTabId === rightId);
+    if (splitIndex !== -1) this.splitPairs.splice(splitIndex, 1);
+
+    if (tabIds.includes(this.activeTabId)) {
+      if (this.tabs.length > 0) {
+        this.selectTab(this.tabs[this.tabs.length - 1].id);
+      }
+    }
+
+    this.saveTabsState();
+
+    const { ipcRenderer } = require('electron');
+    ipcRenderer.send('new-window-with-split-tabs', {
+      leftUrl: leftTab.url,
+      leftTitle: leftTab.title,
+      rightUrl: rightTab.url,
+      rightTitle: rightTab.title,
+      splitRatio: splitRatio,
+      isolate: true 
+    });
+  }
+
   moveTabToNewWindow(tabId) {
     this.destroyHoverCard(); // ensure card removed if this tab had it
     const tab = this.tabs.find(t => t.id === tabId);
@@ -2565,7 +2644,17 @@ restoreTabs(persistedData) {
     const tab = e.target.closest('.tab');
     if (!tab) return;
 
-    this.draggedTab = tab;
+    const split = this.getSplitForTab(tab.id);
+    if (split) {
+      const leftTab = document.getElementById(split.leftTabId);
+      const rightTab = document.getElementById(split.rightTabId);
+      this.draggedElements = [leftTab, rightTab].filter(Boolean);
+    } else {
+      this.draggedElements = [tab];
+    }
+
+    this.primaryDragTarget = tab;
+    
     this.dragStartX = e.clientX;
     this.dragStartY = e.clientY;
     this.isDragging = false;
@@ -2580,7 +2669,7 @@ restoreTabs(persistedData) {
   }
 
   handlePointerMove(e) {
-    if (!this.draggedTab) return;
+    if (!this.draggedElements || this.draggedElements.length === 0) return;
 
     const isVert = this.isVertical;
     const dx = e.clientX - this.dragStartX;
@@ -2590,34 +2679,57 @@ restoreTabs(persistedData) {
       this.isDragging = true;
       this.destroyHoverCard();
 
-      const rect = this.draggedTab.getBoundingClientRect();
-      
-      this.dragOffsetLeft = e.clientX - rect.left;
-      this.dragOffsetTop = e.clientY - rect.top;
+      // Collect bounding rects
+      const rects = this.draggedElements.map(el => el.getBoundingClientRect());
+
+      // Calculate total width and height dynamically based on layout mode
+      let totalWidth = 0;
+      let totalHeight = 0;
+
+      if (isVert) {
+        // Vertical mode: stack heights, use max width
+        totalWidth = Math.max(...rects.map(r => r.width));
+        totalHeight = rects.reduce((sum, r) => sum + r.height, 0);
+      } else {
+        // Horizontal mode: stack widths, use max height
+        totalWidth = rects.reduce((sum, r) => sum + r.width, 0);
+        totalHeight = Math.max(...rects.map(r => r.height));
+      }
+
+      this.dragOffsetLeft = e.clientX - rects[0].left;
+      this.dragOffsetTop = e.clientY - rects[0].top;
 
       this.placeholder = document.createElement('div');
       this.placeholder.className = 'tab-placeholder';
+      this.placeholder.style.width = `${totalWidth}px`;
+      this.placeholder.style.height = `${totalHeight}px`;
 
-      this.placeholder.style.width = `${rect.width}px`;
-      this.placeholder.style.height = `${rect.height}px`;
-
-      this.draggedTab.parentNode.insertBefore(this.placeholder, this.draggedTab);
+      this.draggedElements[0].parentNode.insertBefore(this.placeholder, this.draggedElements[0]);
 
       if (this.webviewContainer) {
         this.webviewContainer.style.pointerEvents = 'none';
       }
 
       this.isMovingDOM = true;
-      document.body.appendChild(this.draggedTab);
+      this.draggedElements.forEach(el => document.body.appendChild(el));
       this.isMovingDOM = false;
 
-      try { this.draggedTab.setPointerCapture(e.pointerId); } catch(err) {}
+      try { this.primaryDragTarget.setPointerCapture(e.pointerId); } catch(err) {}
 
-      this.draggedTab.classList.add('dragging');
-      this.draggedTab.style.setProperty('position', 'fixed', 'important');
-      this.draggedTab.style.zIndex = '9999';
-      this.draggedTab.style.width = `${rect.width}px`;
-      this.draggedTab.style.height = `${rect.height}px`;
+      // Apply drag styles to all involved elements and capture BOTH offsets
+      this.draggedElements.forEach((el, index) => {
+        el.classList.add('dragging');
+        el.style.setProperty('position', 'fixed', 'important');
+        el.style.zIndex = '9999';
+        el.style.width = `${rects[index].width}px`;
+        el.style.height = `${rects[index].height}px`;
+        
+        el.dataset.dragOffsetX = index === 0 ? 0 : (rects[index].left - rects[0].left);
+        el.dataset.dragOffsetY = index === 0 ? 0 : (rects[index].top - rects[0].top);
+      });
+
+      this.dragTotalWidth = totalWidth;
+      this.dragTotalHeight = totalHeight;
     }
 
     if (this.isDragging) {
@@ -2631,37 +2743,76 @@ restoreTabs(persistedData) {
       const floatTop = e.clientY - this.dragOffsetTop;
 
       if (this.isOutsideContainer) {
-        this.draggedTab.style.left = `${floatLeft}px`;
-        this.draggedTab.style.top = `${floatTop}px`;
+        this.draggedElements.forEach(el => {
+          const offsetX = parseFloat(el.dataset.dragOffsetX || 0);
+          const offsetY = parseFloat(el.dataset.dragOffsetY || 0);
+          el.style.left = `${floatLeft + offsetX}px`;
+          el.style.top = `${floatTop + offsetY}px`;
+        });
         if (this.placeholder) this.placeholder.style.display = 'none';
       } else {
         const placeholderRect = this.placeholder.getBoundingClientRect();
         
-        if (isVert) {
-          this.draggedTab.style.left = `${placeholderRect.left}px`;
-          this.draggedTab.style.top = `${floatTop}px`;
-        } else {
-          this.draggedTab.style.top = `${placeholderRect.top}px`;
-          this.draggedTab.style.left = `${floatLeft}px`;
-        }
+        this.draggedElements.forEach(el => {
+          const offsetX = parseFloat(el.dataset.dragOffsetX || 0);
+          const offsetY = parseFloat(el.dataset.dragOffsetY || 0);
+          if (isVert) {
+            el.style.left = `${placeholderRect.left + offsetX}px`;
+            el.style.top = `${floatTop + offsetY}px`;
+          } else {
+            el.style.top = `${placeholderRect.top + offsetY}px`;
+            el.style.left = `${floatLeft + offsetX}px`;
+          }
+        });
         
         if (this.placeholder) this.placeholder.style.display = '';
 
         const draggedCenterRelative = isVert ? 
-              (floatTop + this.draggedTab.offsetHeight / 2) : 
-              (floatLeft + this.draggedTab.offsetWidth / 2);
+              (floatTop + this.dragTotalHeight / 2) : 
+              (floatLeft + this.dragTotalWidth / 2);
         
         const tabs = Array.from(this.tabContainer.querySelectorAll('.tab:not(.dragging)'));
+        
+        const logicalTargets = [];
+        for (let i = 0; i < tabs.length; i++) {
+          const tab = tabs[i];
+          
+          if (tab.classList.contains('split-left')) {
+            const nextTab = tabs[i + 1];
+            if (nextTab && nextTab.classList.contains('split-right')) {
+              const r1 = tab.getBoundingClientRect();
+              const r2 = nextTab.getBoundingClientRect();
+              
+              logicalTargets.push({
+                elementToInsertBefore: tab,
+                rect: {
+                  top: Math.min(r1.top, r2.top),
+                  left: Math.min(r1.left, r2.left),
+                  width: isVert ? Math.max(r1.width, r2.width) : (r1.width + r2.width),
+                  height: isVert ? (r1.height + r2.height) : Math.max(r1.height, r2.height)
+                }
+              });
+              
+              i++; 
+              continue;
+            }
+          }
+          
+          logicalTargets.push({
+            elementToInsertBefore: tab,
+            rect: tab.getBoundingClientRect()
+          });
+        }
+
         let insertBeforeTab = null;
 
-        for (let tab of tabs) {
-          const tabRect = tab.getBoundingClientRect();
+        for (let target of logicalTargets) {
           const tabCenterRelative = isVert ? 
-                (tabRect.top + tabRect.height / 2) : 
-                (tabRect.left + tabRect.width / 2);
+                (target.rect.top + target.rect.height / 2) : 
+                (target.rect.left + target.rect.width / 2);
           
           if (draggedCenterRelative < tabCenterRelative) {
-            insertBeforeTab = tab;
+            insertBeforeTab = target.elementToInsertBefore;
             break;
           }
         }
@@ -2687,63 +2838,85 @@ restoreTabs(persistedData) {
       this.webviewContainer.style.pointerEvents = '';
     }
 
-    if (!this.isDragging || !this.draggedTab) {
-      if (this.draggedTab) {
-        try { this.draggedTab.releasePointerCapture(e.pointerId); } catch(err) {}
+    if (!this.isDragging || !this.draggedElements) {
+      if (this.primaryDragTarget) {
+        try { this.primaryDragTarget.releasePointerCapture(e.pointerId); } catch(err) {}
       }
-      this.draggedTab = null;
+      this.draggedElements = null;
+      this.primaryDragTarget = null;
       return;
     }
 
-    try { this.draggedTab.releasePointerCapture(e.pointerId); } catch(err) {}
+    try { this.primaryDragTarget.releasePointerCapture(e.pointerId); } catch(err) {}
     this.isDragging = false;
-    const tabIdToMove = this.draggedTab.id;
+    
+    const idsToMove = this.draggedElements.map(el => el.id);
 
-    if (this.isOutsideContainer && this.tabs.length > 1) {
-      this.draggedTab.classList.remove('dragging');
+    if (this.isOutsideContainer && this.tabs.length > this.draggedElements.length) {
+      this.draggedElements.forEach(el => {
+        el.classList.remove('dragging');
+        el.remove();
+      });
       
       if (this.placeholder && this.placeholder.parentNode) {
         this.placeholder.remove();
       }
-      this.placeholder = null;
       
-      this.draggedTab.remove(); 
-      this.draggedTab = null;
+      this.placeholder = null;
+      this.draggedElements = null;
+      this.primaryDragTarget = null;
       this.isOutsideContainer = false;
 
-      this.moveTabToNewWindow(tabIdToMove);
+      if (idsToMove.length === 1) {
+        this.moveTabToNewWindow(idsToMove[0]);
+      } else if (idsToMove.length === 2) {
+        this.moveSplitGroupToNewWindow(idsToMove);
+      }
       return;
     }
 
     if (this.placeholder) this.placeholder.style.display = '';
     const placeholderRect = this.placeholder ? this.placeholder.getBoundingClientRect() : { left: 0, top: 0 };
 
-    this.draggedTab.classList.remove('dragging');
-    this.draggedTab.style.transition = 'all 0.2s cubic-bezier(0.25, 0.8, 0.25, 1)';
-    
-    if (this.placeholder) {
-      this.draggedTab.style.left = `${placeholderRect.left}px`;
-      this.draggedTab.style.top = `${placeholderRect.top}px`;
-    }
+    this.draggedElements.forEach(el => {
+      el.classList.remove('dragging');
+      el.style.transition = 'all 0.2s cubic-bezier(0.25, 0.8, 0.25, 1)';
+      const offsetX = parseFloat(el.dataset.dragOffsetX || 0);
+      const offsetY = parseFloat(el.dataset.dragOffsetY || 0);
+
+      if (this.placeholder) {
+        el.style.left = `${placeholderRect.left + offsetX}px`;
+        el.style.top = `${placeholderRect.top + offsetY}px`;
+      }
+    });
+
+    const elementsToCleanup = this.draggedElements;
+    this.draggedElements = null;
+    this.primaryDragTarget = null;
 
     setTimeout(() => {
-      if (!this.draggedTab) return;
+      elementsToCleanup.forEach(el => {
+        el.style.position = '';
+        el.style.left = '';
+        el.style.top = '';
+        el.style.width = '';
+        el.style.height = '';
+        el.style.transition = '';
+        el.style.zIndex = '';
+        delete el.dataset.dragOffsetX;
+        delete el.dataset.dragOffsetY;
 
-      this.draggedTab.style.position = '';
-      this.draggedTab.style.left = '';
-      this.draggedTab.style.top = '';
-      this.draggedTab.style.width = '';
-      this.draggedTab.style.height = '';
-      this.draggedTab.style.transition = '';
-      this.draggedTab.style.zIndex = '';
+        if (this.placeholder && this.placeholder.parentNode) {
+          this.tabContainer.insertBefore(el, this.placeholder);
+        } else {
+          this.tabContainer.appendChild(el);
+        }
+      });
 
-      if (this.placeholder && this.placeholder.parentNode) {
-        this.tabContainer.insertBefore(this.draggedTab, this.placeholder);
+      if (this.placeholder) {
         this.placeholder.remove();
-      } else {
-        this.tabContainer.appendChild(this.draggedTab);
+        this.placeholder = null;
       }
-      this.placeholder = null;
 
       const newTabOrderIds = Array.from(this.tabContainer.querySelectorAll('.tab')).map(el => el.id);
       this.tabs.sort((a, b) => newTabOrderIds.indexOf(a.id) - newTabOrderIds.indexOf(b.id));
@@ -2751,7 +2924,6 @@ restoreTabs(persistedData) {
       this.saveTabsState();
       this.refreshGroupStyles();
 
-      this.draggedTab = null;
     }, 200);
   }
 

--- a/src/pages/tab-bar.js
+++ b/src/pages/tab-bar.js
@@ -1154,7 +1154,29 @@ restoreTabs(persistedData) {
           fontSize: '14px'
         });
 
-        tabBtn.innerHTML = `<img src="peersky://static/assets/icon16.png" style="width:16px; height:16px;"> ${tab.title}`;
+        let currentIconUrl = 'peersky://static/assets/svg/globe.svg';
+
+        const liveTabElement = document.getElementById(tab.id);
+        if (liveTabElement) {
+          const faviconDiv = liveTabElement.querySelector('.tab-favicon');
+          if (faviconDiv && faviconDiv.style.backgroundImage && faviconDiv.style.backgroundImage !== 'none') {
+            const match = faviconDiv.style.backgroundImage.match(/^url\(['"]?([^'"]+)['"]?\)/);
+            if (match && match[1]) {
+              currentIconUrl = match[1];
+            }
+          }
+        }
+
+        const iconImg = document.createElement('img');
+        iconImg.src = currentIconUrl;
+        iconImg.style.width = '16px';
+        iconImg.style.height = '16px';
+
+        const titleText = document.createTextNode(` ${tab.title}`);
+
+        tabBtn.appendChild(iconImg);
+        tabBtn.appendChild(titleText);
+
         tabBtn.onclick = () => this.assignRightSplitTab(tab.id);
         tabsList.appendChild(tabBtn);
       }
@@ -1634,20 +1656,33 @@ restoreTabs(persistedData) {
 
   // Toggle pin state of a tab
   togglePinTab(tabId) {
-    const tabElement = document.getElementById(tabId);
-    if (!tabElement) return;
+    const split = this.getSplitForTab(tabId);
 
-    if (this.pinnedTabs.has(tabId)) {
-      // Unpin tab
-      this.pinnedTabs.delete(tabId);
-      tabElement.classList.remove('pinned');
+    const tabsToProcess = split ? [split.leftTabId, split.rightTabId] : [tabId];
+
+    const isCurrentlyPinned = this.pinnedTabs.has(tabId);
+
+    if (isCurrentlyPinned) {
+      tabsToProcess.forEach(id => {
+        this.pinnedTabs.delete(id);
+        const el = document.getElementById(id);
+        if (el) el.classList.remove('pinned');
+      });
     } else {
-      // Pin tab
-      this.pinnedTabs.add(tabId);
-      tabElement.classList.add('pinned');
-      
-      // Move to leftmost position
-      this.moveTabToPosition(tabId, 0);
+      tabsToProcess.forEach(id => {
+        this.pinnedTabs.add(id);
+        const el = document.getElementById(id);
+        if (el) el.classList.add('pinned');
+      });
+
+      // Move to leftmost position while preserving split order
+      if (split) {
+        this.moveTabToPosition(split.leftTabId, 0);
+        this.moveTabToPosition(split.rightTabId, 1);
+      } else {
+        // Normal single tab move
+        this.moveTabToPosition(tabId, 0);
+      }
     }
     
     this.saveTabsState();

--- a/src/pages/theme/index.css
+++ b/src/pages/theme/index.css
@@ -1260,3 +1260,40 @@ body {
   border-radius: 6px;
   transition: width 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), height 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
+
+.tab.split-left.pinned,
+.tab.split-right.pinned,
+.tab.split-pending.pinned {
+  background-color: var(--browser-theme-primary-highlight) !important;
+  color: var(--browser-theme-background) !important;
+  min-width: 80px !important; 
+  max-width: 120px !important;
+}
+
+.tab.split-left.pinned .tab-title,
+.tab.split-right.pinned .tab-title,
+.tab.split-left.pinned .close-tab,
+.tab.split-right.pinned .close-tab,
+.tab.split-left.pinned .p2p-indicator,
+.tab.split-right.pinned .p2p-indicator {
+  color: var(--browser-theme-background) !important;
+}
+
+.tab.split-left.pinned {
+  border: 3px solid var(--browser-theme-secondary-highlight) !important;
+  border-right: none !important;  
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.tab.split-right.pinned {
+  border: 3px solid var(--browser-theme-secondary-highlight) !important;
+  border-left: 1px solid rgba(0, 0, 0, 0.2) !important;  
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.tab.split-left.pinned .close-tab:hover,
+.tab.split-right.pinned .close-tab:hover {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}

--- a/src/pages/theme/themes.css
+++ b/src/pages/theme/themes.css
@@ -374,3 +374,34 @@ code {
   color: #ffffff;
   background-color: rgba(255, 255, 255, 0.2);
 }
+
+.split-view-divider {
+  width: 6px;
+  background-color: transparent;
+  cursor: col-resize;
+  z-index: 10;
+  position: relative;
+  transition: background-color 0.2s;
+  margin-left: -3px; 
+  margin-right: -3px;
+}
+
+.split-view-divider::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 2px;
+  width: 2px;
+  background-color: var(--settings-border);
+  transition: background-color 0.2s;
+}
+
+.split-view-divider:hover::after,
+.split-view-divider.dragging::after {
+  background-color: var(--browser-theme-primary-highlight);
+}
+
+.split-view-divider.dragging {
+  cursor: col-resize !important;
+}

--- a/src/pages/theme/themes.css
+++ b/src/pages/theme/themes.css
@@ -321,3 +321,56 @@ pre,
 code {
   transition: background-color 0.12s ease-in-out, color 0.12s ease-in-out, border-color 0.12s ease-in-out;
 }
+
+.tab.split-left, 
+.tab.split-right, 
+.tab.split-pending {
+  flex: 0.5 !important;
+  max-width: 140px !important; 
+  min-width: 80px !important;
+  background-color: var(--settings-bg-secondary) !important; 
+  border: 1px solid var(--settings-border) !important;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.tab.split-left {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+  border-right: none !important;
+  margin-right: 0 !important;
+}
+
+.tab.split-right {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+  margin-left: 0 !important;
+  border-left: 1px solid var(--settings-border) !important;
+}
+
+.tab.split-left.active, 
+.tab.split-right.active, 
+.tab.split-pending.active {
+  background-color: var(--browser-theme-secondary-highlight) !important;
+  border-color: var(--browser-theme-secondary-highlight) !important;
+  color: #ffffff !important;
+  z-index: 2;
+}
+
+.tab.split-left.active .tab-title,
+.tab.split-right.active .tab-title,
+.tab.split-pending.active .tab-title {
+  color: #ffffff !important;
+}
+
+.tab.split-left.active .close-tab,
+.tab.split-right.active .close-tab,
+.tab.split-pending.active .close-tab {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.tab.split-left.active .close-tab:hover,
+.tab.split-right.active .close-tab:hover,
+.tab.split-pending.active .close-tab:hover {
+  color: #ffffff;
+  background-color: rgba(255, 255, 255, 0.2);
+}

--- a/src/pages/theme/vertical-tabs.css
+++ b/src/pages/theme/vertical-tabs.css
@@ -435,6 +435,7 @@ body:has(.titlebar.titlebar-collapsed-darwin) .tabbar.vertical-tabs {
   border-top-right-radius: 8px !important;
   border-bottom-left-radius: 0 !important;
   border-bottom-right-radius: 0 !important;
+  border: var(--peersky-nav-button-inactive) 0.5px solid !important;
   border-bottom: 1px solid rgba(128, 128, 128, 0.2) !important;
 }
 
@@ -444,6 +445,7 @@ body:has(.titlebar.titlebar-collapsed-darwin) .tabbar.vertical-tabs {
   border-top-right-radius: 0 !important;
   border-bottom-left-radius: 8px !important;
   border-bottom-right-radius: 8px !important;
+  border: var(--peersky-nav-button-inactive) 0.5px solid !important;
   border-top: none !important;
 }
 
@@ -518,4 +520,43 @@ body:has(.tabbar.vertical-tabs:not(.expanded):not(.keep-expanded)) > .tab.split-
   min-width: 40px !important;
   max-width: 40px !important;
   padding: 4px !important;
+}
+
+.tabbar.vertical-tabs .tab.split-left.pinned,
+.tabbar.vertical-tabs .tab.split-right.pinned,
+.tabbar.vertical-tabs .tab.split-pending.pinned {
+  background-color: var(--browser-theme-primary-highlight) !important;
+  color: var(--browser-theme-background) !important;
+}
+
+.tabbar.vertical-tabs .tab.split-left.pinned .tab-title,
+.tabbar.vertical-tabs .tab.split-right.pinned .tab-title,
+.tabbar.vertical-tabs .tab.split-left.pinned .close-tab,
+.tabbar.vertical-tabs .tab.split-right.pinned .close-tab,
+.tabbar.vertical-tabs .tab.split-left.pinned .p2p-indicator,
+.tabbar.vertical-tabs .tab.split-right.pinned .p2p-indicator {
+  color: var(--browser-theme-background) !important;
+}
+
+.tabbar.vertical-tabs .tab.split-left.pinned {
+  border-top: 3px solid var(--browser-theme-secondary-highlight) !important;
+  border-left: 3px solid var(--browser-theme-secondary-highlight) !important;
+  border-right: 3px solid var(--browser-theme-secondary-highlight) !important;
+  border-bottom: none !important; /* Keep the seam clean to connect to partner */
+}
+
+.tabbar.vertical-tabs .tab.split-right.pinned {
+  border-bottom: 3px solid var(--browser-theme-secondary-highlight) !important;
+  border-left: 3px solid var(--browser-theme-secondary-highlight) !important;
+  border-right: 3px solid var(--browser-theme-secondary-highlight) !important;
+  border-top: 1px solid rgba(0, 0, 0, 0.2) !important; 
+}
+
+.tabbar.vertical-tabs .tab.split-right.pinned::before {
+  display: none !important;
+}
+
+.tabbar.vertical-tabs .tab.split-left.pinned .close-tab:hover,
+.tabbar.vertical-tabs .tab.split-right.pinned .close-tab:hover {
+  background-color: rgba(0, 0, 0, 0.15) !important;
 }

--- a/src/pages/theme/vertical-tabs.css
+++ b/src/pages/theme/vertical-tabs.css
@@ -400,3 +400,122 @@ body:has(.titlebar.titlebar-collapsed-darwin) .tabbar.vertical-tabs {
   border-left: none !important;
   box-shadow: none !important;
 }
+
+.tabbar.vertical-tabs .tab.split-left,
+.tabbar.vertical-tabs .tab.split-right {
+  transform: none !important;
+  position: relative !important;
+  left: auto !important;
+  top: auto !important;
+  margin-left: 4px !important;
+  margin-right: 4px !important;
+}
+
+.tabbar.vertical-tabs:not(.expanded) .tab.split-left,
+.tabbar.vertical-tabs:not(.expanded) .tab.split-right {
+  width: 48px !important;
+  min-width: 48px !important; 
+}
+
+.tabbar.vertical-tabs.expanded .tab.split-left,
+.tabbar.vertical-tabs.expanded .tab.split-right,
+.tabbar.vertical-tabs.keep-expanded .tab.split-left,
+.tabbar.vertical-tabs.keep-expanded .tab.split-right {
+  width: calc(100% - 8px) !important; 
+  min-width: 0 !important;
+  max-width: none !important;
+  flex: 0 0 auto !important;
+  padding: 8px 12px !important; 
+  box-sizing: border-box !important;
+}
+
+.tabbar.vertical-tabs .tab.split-left {
+  margin-bottom: 0 !important;
+  border-top-left-radius: 8px !important;
+  border-top-right-radius: 8px !important;
+  border-bottom-left-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.2) !important;
+}
+
+.tabbar.vertical-tabs .tab.split-right {
+  margin-top: 0 !important;
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+  border-bottom-left-radius: 8px !important;
+  border-bottom-right-radius: 8px !important;
+  border-top: none !important;
+}
+
+.tabbar.vertical-tabs .tab.split-left.active {
+  margin-bottom: 0 !important;
+  border-bottom-left-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.tabbar.vertical-tabs .tab.split-right.active {
+  margin-top: 0 !important;
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+}
+
+.tabbar.vertical-tabs .tab.split-left::before,
+.tabbar.vertical-tabs .tab.split-right::before,
+.tabbar.vertical-tabs .tab.split-left .tab-title::before,
+.tabbar.vertical-tabs .tab.split-right .tab-title::before {
+  display: none !important;
+}
+
+.tabbar.vertical-tabs .tab.split-left.dragging,
+.tabbar.vertical-tabs .tab.split-right.dragging,
+body:has(.tabbar.vertical-tabs) > .tab.split-left.dragging,
+body:has(.tabbar.vertical-tabs) > .tab.split-right.dragging {
+  transform: none !important;
+  opacity: 0.95 !important;
+  margin: 0 !important; 
+  background-color: var(--settings-bg-primary) !important; 
+  border-left: 1px solid var(--peersky-nav-border-color) !important;
+  border-right: 1px solid var(--peersky-nav-border-color) !important;
+  box-sizing: border-box !important;
+}
+
+.tabbar.vertical-tabs .tab.split-left.dragging,
+body:has(.tabbar.vertical-tabs) > .tab.split-left.dragging {
+  border-radius: 8px 8px 0 0 !important; 
+  border-top: 1px solid var(--peersky-nav-border-color) !important;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.2) !important; 
+  box-shadow: 0 -8px 16px rgba(0,0,0,0.1), 4px 0 16px rgba(0,0,0,0.1), -4px 0 16px rgba(0,0,0,0.1) !important;
+}
+
+.tabbar.vertical-tabs .tab.split-right.dragging,
+body:has(.tabbar.vertical-tabs) > .tab.split-right.dragging {
+  border-radius: 0 0 8px 8px !important; 
+  border-bottom: 1px solid var(--peersky-nav-border-color) !important;
+  border-top: none !important;
+  box-shadow: 0 16px 24px rgba(0,0,0,0.2), 4px 0 16px rgba(0,0,0,0.1), -4px 0 16px rgba(0,0,0,0.1) !important;
+}
+
+body:has(.tabbar.vertical-tabs) > .tab.split-left.dragging::before,
+body:has(.tabbar.vertical-tabs) > .tab.split-right.dragging::before,
+body:has(.tabbar.vertical-tabs) > .tab.split-left.dragging .tab-title::before,
+body:has(.tabbar.vertical-tabs) > .tab.split-right.dragging .tab-title::before {
+  display: none !important;
+}
+
+body:has(.tabbar.vertical-tabs.expanded) > .tab.split-left.dragging,
+body:has(.tabbar.vertical-tabs.expanded) > .tab.split-right.dragging,
+body:has(.tabbar.vertical-tabs.keep-expanded) > .tab.split-left.dragging,
+body:has(.tabbar.vertical-tabs.keep-expanded) > .tab.split-right.dragging {
+  width: 192px !important;
+  min-width: 192px !important;
+  max-width: 192px !important;
+  padding: 8px 12px !important;
+}
+
+body:has(.tabbar.vertical-tabs:not(.expanded):not(.keep-expanded)) > .tab.split-left.dragging,
+body:has(.tabbar.vertical-tabs:not(.expanded):not(.keep-expanded)) > .tab.split-right.dragging {
+  width: 40px !important;
+  min-width: 40px !important;
+  max-width: 40px !important;
+  padding: 4px !important;
+}

--- a/src/window-manager.js
+++ b/src/window-manager.js
@@ -116,6 +116,31 @@ class WindowManager {
       this.open();
     });
 
+    // Handles tearing off a single tab into a new window
+    ipcMain.on('new-window-with-tab', (event, data) => {
+      log.info("Creating new window for torn off tab:", data.url);
+      this.open({
+        isolate: true,
+        singleTab: {
+          url: data.url,
+          title: data.title
+        }
+      });
+    });
+
+    // Handles tearing off a split tab pair into a new window
+    ipcMain.on('new-window-with-split-tabs', (event, data) => {
+      log.info("Creating new window for torn off split pair");
+      this.open({
+        isolate: true,
+        splitLeftUrl: data.leftUrl,
+        splitLeftTitle: data.leftTitle,
+        splitRightUrl: data.rightUrl,
+        splitRightTitle: data.rightTitle,
+        splitRatio: data.splitRatio
+      });
+    });
+
     // Explicit quit from UI (custom Quit button, etc.).
     // We just call app.quit(); app.on('before-quit') will save session files.
     ipcMain.on("quit-app", () => {
@@ -915,6 +940,13 @@ class PeerskyWindow {
         ...(singleTab && {
           singleTabUrl: singleTab.url,
           singleTabTitle: singleTab.title
+        }),
+        ...(options.splitLeftUrl && {
+          splitLeftUrl: options.splitLeftUrl,
+          splitLeftTitle: options.splitLeftTitle,
+          splitRightUrl: options.splitRightUrl,
+          splitRightTitle: options.splitRightTitle,
+          splitRatio: options.splitRatio
         })
       }
     };


### PR DESCRIPTION
## Related Issue (if any)

Closes: #179 

### Describe the add-ons or changes you've made

Implemented a fully native, persistent Split View architecture for the browser tab bar. This allows users to view two webviews side-by-side while keeping the tab bar UI clean and intuitive.

**Core Architecture & Logic:**
* **Infinite Split Pairs:** Upgraded state management (`this.splitPairs`) to support multiple independent split views simultaneously.
* **Context Menu Integration:** Added "Split view" and contextual "Separate split view" options.
* **State Persistence:** Integrated split pair data into `getTabsStateForSaving()` and `restoreTabs()` so split groups survive browser restarts and automatically rebuild their DOM structure.

**UI/UX & Styling:**
* **Unified Capsule Design (Vertical Tabs):** When in vertical mode, split tabs visually merge into a single "pill" block. When either half is active, the entire capsule highlights with a distinct center divider.
* **Seamless Drag & Drop:** Rewrote the pointer event engine. If a user drags a split tab, it dynamically wraps both tabs in a `dragWrapper` so they move as a single unit. Tearing the group outside the container gracefully breaks the split and extracts only the grabbed tab.
* **Draggable Resizer:** Injected a dynamic `.split-view-divider` between webviews. Users can drag the seam to smoothly adjust the flex-basis ratio of the left/right panes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

* **Manual UI Testing:** Verified pixel-perfect rendering in both expanded and collapsed vertical tab layouts.
* **Drag & Drop:** Tested reordering split groups within the tab bar and tearing off individual tabs to new windows.
* **Resizer Interaction:** Verified that the center divider correctly calculates percentages and smoothly updates the flexbox layout without `<webview>` iframes swallowing pointer events.
* **Session Restoration:** Reloaded the browser to confirm `localStorage` correctly rebuilds the split DOM and restores the custom webview width ratios.

## Checklist:
- [x] My code follows the "contribution guidelines" of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
