### PR TITLE
feat: move p2pmd PDF export wiring to main setup and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@
   - [x] `peersky://p2p/p2pmd/`
     - Real-time collaborative markdown editor
     - Presentation slides mode with speaker notes
+    - Offline KaTeX math mode with inline scientific templates
+    - IEEE-style two-column research paper preview/export
     - AI-powered content generation
     - Publish to IPFS/Hypercore
     - Peers dashboard with roles, live editing status, and edit history

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { app, session, protocol as globalProtocol, ipcMain, BrowserWindow, Menu, shell, dialog, webContents} from "electron";
+import { app, session, protocol as globalProtocol, ipcMain, BrowserWindow, Menu, shell, webContents} from "electron";
 import { createLogger } from './logger.js';
 import fs from "fs/promises";
 import path from "path";
@@ -27,6 +27,7 @@ import extensionManager from "./extensions/index.js";
 import { setupExtensionIpcHandlers } from "./extensions/extensions-ipc.js";
 import { getBrowserSession, usePersist } from "./session.js";
 import { setupPermissionHandler } from "./permissions.js";
+import { setupP2pmdPdfExportIpc } from "./pages/p2p/p2pmd/pdf-export-ipc.js";
 
 const P2P_PROTOCOL = {
   standard: true,
@@ -860,37 +861,6 @@ ipcMain.handle('check-built-in-engine', (event, template) => {
   }
 });
 
-ipcMain.handle('p2pmd-print-to-pdf', async (event, { html, fileName } = {}) => {
-  const parentWindow = BrowserWindow.fromWebContents(event.sender);
-  const safeName = typeof fileName === "string" && fileName.trim() ? fileName : "p2pmd-document.pdf";
-  const { canceled, filePath } = await dialog.showSaveDialog(parentWindow, {
-    defaultPath: path.join(app.getPath("downloads"), safeName),
-    filters: [{ name: "PDF", extensions: ["pdf"] }]
-  });
-  if (canceled || !filePath) {
-    return { canceled: true };
-  }
-  const printWindow = new BrowserWindow({
-    show: false,
-    webPreferences: {
-      sandbox: false,
-      contextIsolation: true
-    }
-  });
-  try {
-    const dataUrl = `data:text/html;charset=utf-8,${encodeURIComponent(html || "")}`;
-    await printWindow.loadURL(dataUrl);
-    const pdfBuffer = await printWindow.webContents.printToPDF({
-      printBackground: true,
-      preferCSSPageSize: true
-    });
-    await fs.writeFile(filePath, pdfBuffer);
-    return { canceled: false, filePath };
-  } finally {
-    if (!printWindow.isDestroyed()) {
-      printWindow.close();
-    }
-  }
-});
+setupP2pmdPdfExportIpc();
 
 export { windowManager };


### PR DESCRIPTION
## Related Issue (if any)

https://github.com/p2plabsxyz/p2pmd/pull/11

### Describe the add-ons or changes you've made

This PR only updates src/main.js and README.md.

Changes made:
- Refactored PDF export IPC wiring for p2pmd in src/main.js by removing the inline p2pmd print-to-pdf handler and using the centralized setup function from the p2pmd module.
- Updated README.md to reflect the related feature/documentation updates, including KaTeX and IEEE export mention.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- Verified diagnostics for src/main.js: no errors found.
- Verified commit scope includes only src/main.js and README.md.

## Checklist:

- [x] My code follows the contribution guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly wherever it was hard to understand.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.

## Screenshots (Only for Front End and UI/UX Designers)

Original | Updated
:--------------------: |:--------------------:
N/A | N/A
