### PR TITLE
fix(main): avoid accessing destroyed WebContents in trustedUI cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "content-hash": "^2.5.2",
     "content-type": "^1.0.5",
     "datastore-level": "^12.0.2",
-    "@p2plabs/peersky-chrome-extensions": "^1.0.0",
+    "@p2plabs/peersky-chrome-extensions": "^1.1.0",
     "electron-chrome-web-store": "^0.13.0",
     "electron-find": "^1.0.7",
     "electron-log": "^5.3.0",

--- a/src/main.js
+++ b/src/main.js
@@ -84,10 +84,9 @@ let windowManager = null;
 const trustedUIWebContents = new Set();
 
 app.on("browser-window-created", (event, win) => {
-  trustedUIWebContents.add(win.webContents.id);
-  win.webContents.once("destroyed", () =>
-    trustedUIWebContents.delete(win.webContents.id),
-  );
+  const wcId = win.webContents.id;
+  trustedUIWebContents.add(wcId);
+  win.webContents.once("destroyed", () => trustedUIWebContents.delete(wcId));
 });
 
 app.on("web-contents-created", (event, wc) => {

--- a/src/main.js
+++ b/src/main.js
@@ -90,16 +90,17 @@ app.on("browser-window-created", (event, win) => {
 });
 
 app.on("web-contents-created", (event, wc) => {
+  const wcId = wc.id;
   wc.on("did-navigate", (e, url) => {
     if (url.startsWith("peersky://downloads")) {
-      trustedUIWebContents.add(wc.id);
+      trustedUIWebContents.add(wcId);
     } else {
       if (!BrowserWindow.fromWebContents(wc)) {
-        trustedUIWebContents.delete(wc.id);
+        trustedUIWebContents.delete(wcId);
       }
     }
   });
-  wc.once("destroyed", () => trustedUIWebContents.delete(wc.id));
+  wc.once("destroyed", () => trustedUIWebContents.delete(wcId));
 });
 
 const webviewTabShortcutNavAttached = new WeakSet();


### PR DESCRIPTION
Extension popups (and any auxiliary BrowserWindows) destroy their WebContents on close. The browser-window-created handler deleted trusted IDs in a destroyed callback that still read win.webContents.id, which Electron rejects once the object is torn down. Store the id in a local and delete by that value instead.