### PR TITLE
fix(bt): improve torrent lifecycle, state persistence, and peer discovery

### DIFF
--- a/docs/BitTorrent.md
+++ b/docs/BitTorrent.md
@@ -71,7 +71,7 @@ The torrent page communicates with the handler via `bt://api?action=api&api=<act
 ## Privacy & Safety
 
 - **Default no-seeding** — torrents stop automatically on completion unless you explicitly choose **Start Seeding**
-- **LAN / NAT defaults** — normal downloads keep `lsd`, `natUpnp`, and `natPmp` off. When you use **Start Seeding** and no other torrents are active, the worker switches to a seeding network profile with those features on and an upload cap; when seeding stops and the client is idle, it switches back.
+- **LAN / NAT defaults** — `lsd`, `natUpnp`, and `natPmp` are kept off for all modes to maximize tracker compatibility
 - **IP visibility** — your IP is visible to peers during download, and while seeding if you enable it
 - **Upload during download** — pieces are shared with peers while downloading (BitTorrent protocol requirement)
 - **Stop control** — you can stop active seeding at any time using **Stop Seeding**

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ import { createHandler as createHyperHandler } from "./protocols/hyper-handler.j
 import { createHandler as createHSHandler } from "./protocols/hs-handler.js";
 import { createHandler as createWeb3Handler } from "./protocols/web3-handler.js";
 import { createHandler as createFileHandler } from "./protocols/file-handler.js";
-import { createHandler as createBittorrentHandler, setupBittorrentIpc } from "./protocols/bittorrent-handler.js";
+import { createHandler as createBittorrentHandler, setupBittorrentIpc, shutdownBittorrent } from "./protocols/bittorrent-handler.js";
 import { ipfsOptions, hyperOptions } from "./protocols/config.js";
 import { createMenuTemplate } from "./actions.js";
 import WindowManager from "./window-manager.js";
@@ -338,6 +338,14 @@ app.on("before-quit", async (event) => {
   isQuitting = true; // Set the quitting flag
 
   windowManager.setQuitting(true); // Inform WindowManager that quitting is happening
+
+  // Shutdown BitTorrent — save state and kill worker before process exits
+  try {
+    shutdownBittorrent();
+    log.info("BitTorrent shutdown successfully");
+  } catch (error) {
+    log.error("Error shutting down BitTorrent:", error);
+  }
 
   // Shutdown extension system
   try {

--- a/src/protocols/bittorrent-handler.js
+++ b/src/protocols/bittorrent-handler.js
@@ -10,6 +10,7 @@ import { ipcMain } from "electron";
 import parseTorrent from "parse-torrent";
 import mime from "mime-types";
 import { randomBytes } from "crypto";
+import DEFAULT_TRACKERS from "./bt/trackers.json" with { type: "json" };
 
 const log = createLogger('protocols:bt');
 
@@ -51,15 +52,23 @@ function loadTorrentStateCache() {
   }
 }
 
+let _savePending = null;
+const _saveQueue = new Map();
 function saveTorrentState(infoHash, status) {
-  try {
-    const cachePath = getTorrentStateCachePath();
-    const data = fs.existsSync(cachePath) ? fs.readJsonSync(cachePath) : {};
-    data[infoHash] = status;
-    fs.writeJsonSync(cachePath, data, { spaces: 2 });
-  } catch (err) {
-    log.error("[BT] Failed to save torrent state:", err.message);
-  }
+  _saveQueue.set(infoHash, status);
+  if (_savePending) return;
+  _savePending = setTimeout(() => {
+    _savePending = null;
+    try {
+      const cachePath = getTorrentStateCachePath();
+      const data = fs.existsSync(cachePath) ? fs.readJsonSync(cachePath) : {};
+      for (const [hash, s] of _saveQueue) data[hash] = s;
+      _saveQueue.clear();
+      fs.writeJsonSync(cachePath, data, { spaces: 2 });
+    } catch (err) {
+      log.error("[BT] Failed to save torrent state:", err.message);
+    }
+  }, 500);
 }
 
 function removeTorrentState(infoHash) {
@@ -76,10 +85,29 @@ function removeTorrentState(infoHash) {
 }
 
 async function removeTorrentFilesFromDisk(status) {
-  if (!status || !Array.isArray(status.files) || status.files.length === 0) return;
+  if (!status) return;
   const basePath = path.resolve(
     status.downloadPath || path.join(app.getPath("downloads"), "PeerskyTorrents")
   );
+
+  // If we know the torrent name, remove its folder directly (handles multi-file torrents)
+  if (status.name && status.name !== "Fetching metadata...") {
+    const torrentFolder = path.resolve(basePath, status.name);
+    if (torrentFolder !== basePath && torrentFolder.startsWith(`${basePath}${path.sep}`)) {
+      try {
+        if (await fs.pathExists(torrentFolder)) {
+          await fs.remove(torrentFolder);
+          log.info(`[BT] Removed torrent folder: ${torrentFolder}`);
+          return;
+        }
+      } catch (err) {
+        log.warn(`[BT] Failed to remove torrent folder ${torrentFolder}: ${err.message}`);
+      }
+    }
+  }
+
+  // Fallback: remove individual files from the files list
+  if (!Array.isArray(status.files) || status.files.length === 0) return;
   const uniquePaths = new Set();
   for (const file of status.files) {
     if (!file || typeof file.path !== "string" || !file.path) continue;
@@ -98,42 +126,20 @@ async function removeTorrentFilesFromDisk(status) {
   }
 }
 
-// Load persisted torrent states on module init
-
-const DEFAULT_TRACKERS = [
-  "wss://tracker.openwebtorrent.com",
-  "wss://tracker.btorrent.xyz",
-  "wss://tracker.webtorrent.dev",
-  "wss://tracker.files.fm:7073/announce",
-  "wss://tracker.fastcast.nz",
-  "udp://tracker.opentrackr.org:1337/announce",
-  "udp://open.tracker.cl:1337/announce",
-  "udp://tracker.openbittorrent.com:6969/announce",
-  "udp://open.stealth.si:80/announce",
-  "udp://tracker.torrent.eu.org:451/announce",
-  "udp://exodus.desync.com:6969/announce",
-  "udp://tracker.moeking.me:6969/announce",
-  "udp://tracker.dler.org:6969/announce",
-  "udp://tracker.0x7c0.com:6969/announce",
-  "udp://tracker.theoks.net:6969/announce",
-  "udp://tracker1.bt.moack.co.kr:80/announce",
-  "udp://tracker2.dler.org:80/announce",
-  "udp://tracker.bittor.pw:1337/announce",
-  "udp://tracker.dler.com:6969/announce",
-];
-
-function mergeTrackerLists(...lists) {
-  const merged = [];
-  for (const list of lists) {
-    if (!Array.isArray(list)) continue;
-    for (const tracker of list) {
-      if (typeof tracker !== "string") continue;
-      const trimmed = tracker.trim();
-      if (!trimmed) continue;
-      merged.push(trimmed);
+function buildTrackerList(magnetUri) {
+  const seen = new Set(DEFAULT_TRACKERS);
+  const merged = [...DEFAULT_TRACKERS];
+  try {
+    const url = new URL(magnetUri);
+    for (const tr of url.searchParams.getAll("tr")) {
+      const t = (tr || "").trim();
+      if (t && !seen.has(t)) {
+        seen.add(t);
+        merged.push(t);
+      }
     }
-  }
-  return [...new Set(merged)];
+  } catch {}
+  return merged;
 }
 
 function createUiApiToken() {
@@ -298,6 +304,18 @@ async function initializeWorker() {
     }, 10000);
   });
 
+  // Periodically save in-progress torrent states as crash safety net
+  setInterval(() => {
+    const active = Array.from(statusCache.entries()).filter(([, s]) => !s.done && s.progress > 0);
+    if (active.length === 0) return;
+    try {
+      const cachePath = getTorrentStateCachePath();
+      const data = fs.existsSync(cachePath) ? fs.readJsonSync(cachePath) : {};
+      for (const [hash, status] of active) data[hash] = { ...status, paused: true };
+      fs.writeJsonSync(cachePath, data, { spaces: 2 });
+    } catch {}
+  }, 30000);
+
   log.info("[BT] Worker initialized. Download path:", downloadPath);
 }
 
@@ -397,6 +415,30 @@ export async function createHandler() {
       });
     }
   };
+}
+
+export function shutdownBittorrent() {
+  // Save in-progress torrent states so they survive app restart
+  try {
+    const cachePath = getTorrentStateCachePath();
+    const data = fs.existsSync(cachePath) ? fs.readJsonSync(cachePath) : {};
+    for (const [hash, status] of statusCache.entries()) {
+      if (!status.done) {
+        data[hash] = { ...status, paused: true };
+      }
+    }
+    fs.writeJsonSync(cachePath, data, { spaces: 2 });
+    log.info(`[BT] Saved ${Object.keys(data).length} torrent state(s) on shutdown`);
+  } catch (err) {
+    log.error("[BT] Failed to save torrent states on shutdown:", err.message);
+  }
+
+  // Kill worker immediately — no async wait
+  if (worker) {
+    try { worker.kill("SIGKILL"); } catch {}
+    worker = null;
+    workerReady = false;
+  }
 }
 
 export function setupBittorrentIpc() {
@@ -518,89 +560,51 @@ function jsonResponse(data, status = 200, { allowCors = true } = {}) {
   });
 }
 
-async function startTorrent(magnetUri, responseOptions = {}) {
+async function addTorrentCommand(action, magnetUri, hash, responseOptions = {}) {
   try {
-    // Decode the magnet URI
-    const decoded = decodeURIComponent(magnetUri);
-    const hash = extractInfoHash(decoded);
-    log.info(`[BT] startTorrent: hash=${hash}`);
-
-    // Merge all trackers from the magnet + defaults
-    let allTrackers = [...DEFAULT_TRACKERS];
-    try {
-      const url = new URL(decoded);
-      const magnetTrackers = url.searchParams.getAll("tr");
-      allTrackers = mergeTrackerLists(magnetTrackers, DEFAULT_TRACKERS);
-    } catch (e) { /* ignore parse errors */ }
-
-    // Send to worker process
-    const result = await sendCommand("start", {
-      magnetUri: decoded,
-      announce: allTrackers,
-    });
-
-    if (result.error) {
-      return jsonResponse({ error: result.error }, 400, responseOptions);
-    }
-
-    return jsonResponse({
-      success: true,
-      infoHash: result.infoHash || hash,
-      magnetURI: decoded,
-    }, 200, responseOptions);
-  } catch (err) {
-    log.error("[BT] startTorrent error:", err);
-    return jsonResponse({ error: err.message }, 500, responseOptions);
-  }
-}
-
-async function seedTorrent(magnetUri, hash, responseOptions = {}) {
-  try {
-    let decoded = null;
-    if (magnetUri) {
-      decoded = decodeURIComponent(magnetUri);
-    } else if (hash) {
+    let resolvedMagnet = magnetUri || null;
+    if (!resolvedMagnet && hash) {
       const cached = statusCache.get(hash);
-      if (cached?.magnetURI) {
-        decoded = cached.magnetURI;
-      }
+      if (cached?.magnetURI) resolvedMagnet = cached.magnetURI;
+    }
+    if (!resolvedMagnet) {
+      return jsonResponse({ error: `${action} requires magnet URI` }, 400, responseOptions);
     }
 
-    if (!decoded) {
-      return jsonResponse({ error: "seed requires magnet or hash with cached magnetURI" }, 400, responseOptions);
-    }
-
-    // Merge all trackers from the magnet + defaults
-    let allTrackers = [...DEFAULT_TRACKERS];
-    try {
-      const url = new URL(decoded);
-      const magnetTrackers = url.searchParams.getAll("tr");
-      allTrackers = mergeTrackerLists(magnetTrackers, DEFAULT_TRACKERS);
-    } catch (e) { /* ignore parse errors */ }
-
-    const result = await sendCommand("seed", {
+    const decoded = decodeURIComponent(resolvedMagnet);
+    const result = await sendCommand(action, {
       magnetUri: decoded,
-      announce: allTrackers,
+      announce: buildTrackerList(decoded),
     });
 
     if (result.error) {
-      if (result.error.includes("Unknown action: seed")) {
-        return jsonResponse({ error: "Seed mode is not available yet in worker" }, 501, responseOptions);
-      }
       return jsonResponse({ error: result.error }, 400, responseOptions);
     }
 
+    const infoHash = result.infoHash || extractInfoHash(decoded);
+    if (infoHash && !statusCache.has(infoHash)) {
+      statusCache.set(infoHash, {
+        infoHash, name: result.name || "Fetching metadata...",
+        mode: action === "seed" ? "seed" : "download",
+        magnetURI: decoded, downloadPath: path.join(app.getPath("downloads"), "PeerskyTorrents"),
+        progress: 0, downloaded: 0, uploaded: 0,
+        downloadSpeed: 0, uploadSpeed: 0, numPeers: 0,
+        done: false, paused: false, files: [],
+      });
+    }
+
     return jsonResponse({
-      success: true,
-      infoHash: result.infoHash || extractInfoHash(decoded),
-      magnetURI: decoded,
-      mode: "seed",
+      success: true, infoHash, magnetURI: decoded,
+      mode: action === "seed" ? "seed" : "download",
     }, 200, responseOptions);
   } catch (err) {
-    log.error("[BT] seedTorrent error:", err);
+    log.error(`[BT] ${action} error:`, err);
     return jsonResponse({ error: err.message }, 500, responseOptions);
   }
 }
+
+const startTorrent = (magnetUri, opts) => addTorrentCommand("start", magnetUri, null, opts);
+const seedTorrent = (magnetUri, hash, opts) => addTorrentCommand("seed", magnetUri, hash, opts);
 
 async function unseedTorrent(hash, responseOptions = {}) {
   try {
@@ -615,6 +619,10 @@ async function unseedTorrent(hash, responseOptions = {}) {
       cached.isSeeding = false;
       cached.seedingSince = null;
       cached.paused = true;
+      cached.downloadSpeed = 0;
+      cached.uploadSpeed = 0;
+      cached.numPeers = 0;
+      cached.timeRemaining = null;
       saveTorrentState(hash, cached);
     }
     return jsonResponse({ success: true, infoHash: hash, mode: "download", paused: true }, 200, responseOptions);
@@ -678,9 +686,9 @@ async function pauseResumeTorrent(action, hash, responseOptions = {}) {
           removeTorrentState(hash);
           statusCache.delete(hash);
           if (cached.mode === "seed") {
-          return await seedTorrent(encodeURIComponent(cached.magnetURI), hash, responseOptions);
+            return await seedTorrent(cached.magnetURI, hash, responseOptions);
           }
-          return await startTorrent(encodeURIComponent(cached.magnetURI), responseOptions);
+          return await startTorrent(cached.magnetURI, responseOptions);
         }
       }
       return jsonResponse({ error: result.error }, 404, responseOptions);

--- a/src/protocols/bt/torrentPage.js
+++ b/src/protocols/bt/torrentPage.js
@@ -548,10 +548,12 @@ export function generateTorrentUI(magnetUrl, torrentId, protocol, displayName, t
       var btn = document.getElementById('stopSeedBtn');
       btn.disabled = true;
       btn.textContent = 'Stopping...';
+      clearInterval(statusInterval);
+      statusInterval = null;
       try {
         var data = await apiCall('unseed', { hash: currentInfoHash || '' });
         if (data && data.success) {
-          showStatus('Seeding stopped.', 'info');
+          showStatus('Seeding stopped. Files remain in Downloads/PeerskyTorrents.', 'success');
           btn.style.display = 'none';
           btn.textContent = 'Stop Seeding';
           document.getElementById('seedBtn').style.display = 'inline-block';
@@ -560,17 +562,22 @@ export function generateTorrentUI(magnetUrl, torrentId, protocol, displayName, t
           document.getElementById('pauseBtn').style.display = 'none';
           document.getElementById('resumeBtn').style.display = 'none';
           document.getElementById('stopBtn').style.display = 'none';
-          clearInterval(statusInterval);
-          statusInterval = null;
+          document.getElementById('downloadSpeed').textContent = '0 B/s';
+          document.getElementById('uploadSpeed').textContent = '0 B/s';
+          document.getElementById('peers').textContent = '0';
+          document.getElementById('timeRemaining').textContent = '-';
+          document.getElementById('seedingTime').textContent = '-';
         } else {
           showStatus('Failed to stop seeding: ' + ((data && data.error) || 'Unknown error'), 'error');
           btn.disabled = false;
           btn.textContent = 'Stop Seeding';
+          statusInterval = setInterval(pollStatus, 2000);
         }
       } catch (err) {
         showStatus('Error stopping seeding: ' + err.message, 'error');
         btn.disabled = false;
         btn.textContent = 'Stop Seeding';
+        statusInterval = setInterval(pollStatus, 2000);
       }
     }
 

--- a/src/protocols/bt/trackers.json
+++ b/src/protocols/bt/trackers.json
@@ -1,0 +1,13 @@
+[
+  "wss://tracker.openwebtorrent.com",
+  "wss://tracker.btorrent.xyz",
+  "wss://tracker.webtorrent.dev",
+  "https://tracker.opentrackr.org:443/announce",
+  "http://tracker.opentrackr.org:1337/announce",
+  "udp://tracker.opentrackr.org:1337/announce",
+  "udp://open.tracker.cl:1337/announce",
+  "udp://tracker.openbittorrent.com:6969/announce",
+  "udp://open.stealth.si:80/announce",
+  "udp://tracker.torrent.eu.org:451/announce",
+  "udp://exodus.desync.com:6969/announce"
+]

--- a/src/protocols/bt/worker.js
+++ b/src/protocols/bt/worker.js
@@ -1,211 +1,117 @@
-/**
- * BitTorrent Worker Process
- * Runs WebTorrent in a separate Node.js process to avoid native module crashes in Electron.
- * Communicates with the main process via IPC (process.send / process.on('message')).
- * Pushes status updates periodically so the handler can serve cached data instantly.
- */
 import WebTorrent from "webtorrent";
 import path from "path";
 import fs from "fs";
 
 const downloadPath = process.argv[2] || path.join(process.env.HOME || "/tmp", "Downloads", "PeerskyTorrents");
-
-// Ensure download directory exists
-if (!fs.existsSync(downloadPath)) {
-  fs.mkdirSync(downloadPath, { recursive: true });
-}
+if (!fs.existsSync(downloadPath)) fs.mkdirSync(downloadPath, { recursive: true });
 
 let client = null;
 const torrentModes = new Map();
 const seedingStartedAt = new Map();
-
-// Seed profile: stronger reachability + upload cap. Applied only when no other torrents are active.
-const SEED_UPLOAD_BYTES_PER_SEC = 5 * 1024 * 1024;
-
-function send(msg) {
-  try {
-    if (process.send) process.send(msg);
-  } catch (err) {
-    console.error("[BT-Worker] Failed to send IPC message:", err.message);
-  }
-}
-
-function createWebTorrentClient(profile) {
-  const seed = profile === "seed";
-  const c = new WebTorrent({
-    maxConns: 55,
-    uploadLimit: seed ? SEED_UPLOAD_BYTES_PER_SEC : -1,
-    lsd: seed,
-    natUpnp: seed,
-    natPmp: seed,
-  });
-  c._networkProfile = seed ? "seed" : "download";
-  c.on("error", (err) => {
-    console.error("[BT-Worker] Client error:", err.message);
-    send({ type: "client-error", error: err.message });
-  });
-  return c;
-}
-
-function initClient() {
-  if (client) return;
-  client = createWebTorrentClient("download");
-  console.log("[BT-Worker] WebTorrent client initialized. Download path:", downloadPath);
-  send({ type: "ready" });
-}
-
-async function ensureSeedingNetwork() {
-  if (client && client._networkProfile === "seed") return true;
-  if (client && client.torrents.length > 0) {
-    console.warn(
-      "[BT-Worker] LSD/NAT seed profile not applied while other torrents are active; finish or remove them, then start seeding again."
-    );
-    return false;
-  }
-  if (client) {
-    await new Promise((resolve) => {
-      client.destroy(() => resolve());
-    });
-    client = null;
-  }
-  client = createWebTorrentClient("seed");
-  console.log(
-    `[BT-Worker] Network profile: seed (lsd/nat upnp+pmp on, upload cap ${SEED_UPLOAD_BYTES_PER_SEC} B/s).`
-  );
-  return true;
-}
-
-async function maybeUseDownloadProfileWhenIdle() {
-  if (!client || client.torrents.length > 0) return;
-  if (client._networkProfile !== "seed") return;
-  await new Promise((resolve) => {
-    client.destroy(() => resolve());
-  });
-  client = null;
-  client = createWebTorrentClient("download");
-  console.log("[BT-Worker] Network profile: download (idle, no LSD/NAT).");
-}
-
-// Initialize immediately
-initClient();
-
-// Track previous status to avoid redundant updates
 const previousStatus = new Map();
 
-function clearTorrentTracking(infoHash) {
+function send(msg) {
+  try { if (process.send) process.send(msg); } catch {}
+}
+
+function clearTracking(infoHash) {
   torrentModes.delete(infoHash);
   seedingStartedAt.delete(infoHash);
   previousStatus.delete(infoHash);
 }
 
-function hasStatusChanged(infoHash, newStatus) {
+function initClient() {
+  if (client) return;
+  client = new WebTorrent({
+    maxConns: 55,
+    uploadLimit: -1,
+    lsd: false,
+    natUpnp: false,
+    natPmp: false,
+  });
+  client.on("error", (err) => {
+    console.error("[BT-Worker] Client error:", err.message);
+    send({ type: "client-error", error: err.message });
+  });
+  console.log("[BT-Worker] WebTorrent client initialized. Download path:", downloadPath);
+  send({ type: "ready" });
+}
+
+initClient();
+
+function hasStatusChanged(infoHash, s) {
   const prev = previousStatus.get(infoHash);
   if (!prev) return true;
-  
-  // Check if significant fields changed (ignore minor fluctuations)
   return (
-    prev.progress !== newStatus.progress ||
-    prev.uploaded !== newStatus.uploaded ||
-    prev.downloadSpeed !== newStatus.downloadSpeed ||
-    prev.uploadSpeed !== newStatus.uploadSpeed ||
-    prev.numPeers !== newStatus.numPeers ||
-    prev.done !== newStatus.done ||
-    prev.paused !== newStatus.paused ||
-    prev.mode !== newStatus.mode ||
-    prev.isSeeding !== newStatus.isSeeding ||
-    prev.seedingSince !== newStatus.seedingSince
+    prev.progress !== s.progress ||
+    prev.uploaded !== s.uploaded ||
+    prev.downloadSpeed !== s.downloadSpeed ||
+    prev.uploadSpeed !== s.uploadSpeed ||
+    prev.numPeers !== s.numPeers ||
+    prev.done !== s.done ||
+    prev.paused !== s.paused ||
+    prev.mode !== s.mode ||
+    prev.isSeeding !== s.isSeeding ||
+    prev.seedingSince !== s.seedingSince
   );
 }
 
-// --- Periodic status push (every 2 seconds) ---
+function buildStatus(torrent) {
+  const mode = torrentModes.get(torrent.infoHash) || "download";
+  const isSeeding = mode === "seed" && torrent.done && !torrent.paused;
+  if (isSeeding && !seedingStartedAt.has(torrent.infoHash)) {
+    seedingStartedAt.set(torrent.infoHash, Date.now());
+  }
+  return {
+    infoHash: torrent.infoHash,
+    name: torrent.name || "Fetching metadata...",
+    downloadPath,
+    mode,
+    isSeeding,
+    seedingSince: isSeeding ? seedingStartedAt.get(torrent.infoHash) : null,
+    progress: torrent.progress,
+    downloaded: torrent.downloaded,
+    uploaded: torrent.uploaded,
+    downloadSpeed: torrent.downloadSpeed,
+    uploadSpeed: torrent.uploadSpeed,
+    ratio: torrent.ratio,
+    numPeers: torrent.numPeers,
+    timeRemaining: torrent.timeRemaining === Infinity ? null : torrent.timeRemaining,
+    done: torrent.done,
+    paused: torrent.paused,
+    files: torrent.files
+      ? torrent.files.map((f, i) => ({ index: i, name: f.name, path: f.path, length: f.length, downloaded: f.downloaded, progress: f.progress }))
+      : [],
+    magnetURI: torrent.magnetURI,
+  };
+}
+
 setInterval(() => {
   if (!client || client.torrents.length === 0) return;
-
   const updates = [];
-  
   for (const torrent of client.torrents) {
     if (!torrent.infoHash) continue;
-    const mode = torrentModes.get(torrent.infoHash) || "download";
-    const isSeeding = mode === "seed" && torrent.done && !torrent.paused;
-    if (isSeeding && !seedingStartedAt.has(torrent.infoHash)) {
-      seedingStartedAt.set(torrent.infoHash, Date.now());
-    }
-    
-    const status = {
-      infoHash: torrent.infoHash,
-      name: torrent.name || "Fetching metadata...",
-      downloadPath,
-      mode,
-      isSeeding,
-      seedingSince: isSeeding ? seedingStartedAt.get(torrent.infoHash) : null,
-      progress: torrent.progress,
-      downloaded: torrent.downloaded,
-      uploaded: torrent.uploaded,
-      downloadSpeed: torrent.downloadSpeed,
-      uploadSpeed: torrent.uploadSpeed,
-      ratio: torrent.ratio,
-      numPeers: torrent.numPeers,
-      timeRemaining: torrent.timeRemaining === Infinity ? null : torrent.timeRemaining,
-      done: torrent.done,
-      paused: torrent.paused,
-      files: torrent.files
-        ? torrent.files.map((f, i) => ({
-            index: i,
-            name: f.name,
-            path: f.path,
-            length: f.length,
-            downloaded: f.downloaded,
-            progress: f.progress,
-          }))
-        : [],
-      magnetURI: torrent.magnetURI,
-    };
-    
-    // Only send if status changed
+    const status = buildStatus(torrent);
     if (hasStatusChanged(torrent.infoHash, status)) {
       updates.push(status);
       previousStatus.set(torrent.infoHash, status);
     }
   }
-  
-  // Send bulk update if there are changes
-  if (updates.length > 0) {
-    send({
-      type: "status-update-bulk",
-      torrents: updates
-    });
-  }
+  if (updates.length > 0) send({ type: "status-update-bulk", torrents: updates });
 }, 2000);
 
-// --- IPC Command Handler ---
 process.on("message", (msg) => {
   const { id, action, ...params } = msg;
-
   try {
     switch (action) {
-      case "start":
-        handleStart(id, params);
-        break;
-      case "seed":
-        handleSeed(id, params);
-        break;
-      case "pause":
-        handlePause(id, params);
-        break;
-      case "unseed":
-        handleUnseed(id, params);
-        break;
-      case "resume":
-        handleResume(id, params);
-        break;
-      case "stop":
-        handleStop(id, params);
-        break;
-      case "remove":
-        handleRemove(id, params);
-        break;
-      default:
-        send({ id, error: `Unknown action: ${action}` });
+      case "start": return handleStart(id, params);
+      case "seed": return handleSeed(id, params);
+      case "pause": return handlePause(id, params);
+      case "unseed": return handleUnseed(id, params);
+      case "resume": return handleResume(id, params);
+      case "stop": return handleStop(id, params);
+      case "remove": return handleRemove(id, params);
+      default: send({ id, error: `Unknown action: ${action}` });
     }
   } catch (err) {
     console.error("[BT-Worker] Error handling message:", err);
@@ -218,63 +124,10 @@ function extractHash(uri) {
   return match ? match[1].toLowerCase() : null;
 }
 
-async function handleStart(id, { magnetUri, announce }) {
-  return handleAddTorrent(id, { magnetUri, announce, mode: "download" });
-}
-
-async function handleSeed(id, { magnetUri, announce }) {
-  return handleAddTorrent(id, { magnetUri, announce, mode: "seed" });
-}
-
-async function handleAddTorrent(id, { magnetUri, announce, mode = "download" }) {
-  if (!client) {
-    send({ id, error: "Client not initialized" });
-    return;
-  }
-
-  if (mode === "seed") {
-    const seedingNetworkReady = await ensureSeedingNetwork();
-    if (!seedingNetworkReady) {
-      send({
-        id,
-        error: "Cannot start seeding while other torrents are active. Stop or finish active torrents and try again.",
-      });
-      return;
-    }
-  }
-
-  // Extract infoHash and check by hash, not by full URI
-  const hash = extractHash(magnetUri);
-  console.log(`[BT-Worker] ${mode} requested. Hash: ${hash}, Announce: ${(announce || []).length} trackers`);
-
-  if (hash) {
-    const existing = await client.get(hash);
-    if (existing && existing.infoHash) {
-      if (mode === "seed") {
-        torrentModes.set(existing.infoHash, "seed");
-      }
-      console.log("[BT-Worker] Torrent already active:", existing.infoHash, existing.name || "no name yet");
-      send({
-        id,
-        type: "started",
-        infoHash: existing.infoHash,
-        magnetURI: existing.magnetURI,
-        name: existing.name,
-        mode: torrentModes.get(existing.infoHash) || "download",
-      });
-      return;
-    }
-  }
-
-  console.log("[BT-Worker] Adding torrent to client...");
-  const torrent = client.add(magnetUri, {
-    path: downloadPath,
-    announce: announce || [],
-  });
-
+function attachTorrentEvents(torrent, mode) {
   torrent.on("infoHash", () => {
-    torrentModes.set(torrent.infoHash, mode === "seed" ? "seed" : "download");
-    console.log(`[BT-Worker] InfoHash resolved: ${torrent.infoHash}`);
+    torrentModes.set(torrent.infoHash, mode);
+    console.log(`[BT-Worker] InfoHash resolved: ${torrent.infoHash} (${mode})`);
   });
 
   torrent.on("metadata", () => {
@@ -288,55 +141,19 @@ async function handleAddTorrent(id, { magnetUri, announce, mode = "download" }) 
   torrent.on("done", () => {
     const infoHash = torrent.infoHash;
     const currentMode = torrentModes.get(infoHash) || "download";
-    const keepSeeding = currentMode === "seed";
-    if (keepSeeding && !seedingStartedAt.has(infoHash)) {
-      seedingStartedAt.set(infoHash, Date.now());
+    if (currentMode === "seed") {
+      if (!seedingStartedAt.has(infoHash)) seedingStartedAt.set(infoHash, Date.now());
+      console.log(`[BT-Worker] Download complete: ${torrent.name}. Seeding.`);
+      send({ type: "status-update", ...buildStatus(torrent) });
+      return;
     }
-    if (keepSeeding) {
-      console.log(`[BT-Worker] Download complete: ${torrent.name}. Keeping torrent alive for seeding.`);
-    } else {
-      console.log(`[BT-Worker] Download complete: ${torrent.name}. Destroying torrent to prevent seeding.`);
-    }
-    // Send final status with all file info before destroying
-    send({
-      type: "status-update",
-      infoHash,
-      name: torrent.name,
-      downloadPath,
-      mode: currentMode,
-      isSeeding: keepSeeding,
-      seedingSince: keepSeeding ? seedingStartedAt.get(infoHash) : null,
-      progress: 1,
-      downloaded: torrent.downloaded,
-      uploaded: torrent.uploaded,
-      downloadSpeed: keepSeeding ? torrent.downloadSpeed : 0,
-      uploadSpeed: keepSeeding ? torrent.uploadSpeed : 0,
-      ratio: torrent.ratio,
-      numPeers: keepSeeding ? torrent.numPeers : 0,
-      timeRemaining: 0,
-      done: true,
-      paused: false,
-      files: torrent.files
-        ? torrent.files.map((f, i) => ({
-            index: i,
-            name: f.name,
-            path: f.path,
-            length: f.length,
-            downloaded: f.downloaded,
-            progress: f.progress,
-          }))
-        : [],
-      magnetURI: torrent.magnetURI,
+    console.log(`[BT-Worker] Download complete: ${torrent.name}. Destroying (no seeding).`);
+    send({ type: "status-update", ...buildStatus(torrent), downloadSpeed: 0, uploadSpeed: 0, numPeers: 0 });
+    send({ type: "done", infoHash });
+    torrent.destroy({ destroyStore: false }, () => {
+      clearTracking(infoHash);
+      console.log(`[BT-Worker] Torrent destroyed: ${infoHash}`);
     });
-    // Destroy immediately for download mode; keep alive in explicit seed mode.
-    if (!keepSeeding) {
-      send({ type: "done", infoHash });
-      torrent.destroy({ destroyStore: false }, () => {
-        clearTorrentTracking(infoHash);
-        console.log(`[BT-Worker] Torrent destroyed (no seeding): ${infoHash}`);
-        void maybeUseDownloadProfileWhenIdle();
-      });
-    }
   });
 
   torrent.on("error", (err) => {
@@ -345,178 +162,122 @@ async function handleAddTorrent(id, { magnetUri, announce, mode = "download" }) 
   });
 
   torrent.on("warning", (warn) => {
-    const msg = typeof warn === "object" ? warn.message : warn;
-    // Only log non-DNS warnings to reduce noise
-    if (!msg.includes("getaddrinfo")) {
-      console.warn(`[BT-Worker] Warning:`, msg);
-    }
+    const m = typeof warn === "object" ? warn.message : warn;
+    if (!m.includes("getaddrinfo")) console.warn(`[BT-Worker] Warning:`, m);
   });
 
-  // Periodic progress logging (every 10s to reduce noise)
-  let lastLogTime = 0;
+  let lastLog = 0;
   torrent.on("download", () => {
     const now = Date.now();
-    if (now - lastLogTime > 10000) {
-      lastLogTime = now;
+    if (now - lastLog > 10000) {
+      lastLog = now;
       console.log(
         `[BT-Worker] Progress: ${(torrent.progress * 100).toFixed(1)}%, ` +
         `${(torrent.downloaded / (1024 * 1024)).toFixed(1)} MB, ` +
-        `${(torrent.downloadSpeed / 1024).toFixed(1)} KB/s, ` +
-        `${torrent.numPeers} peers`
+        `${(torrent.downloadSpeed / 1024).toFixed(1)} KB/s, ${torrent.numPeers} peers`
       );
     }
   });
-
-  // Send initial response
-  send({
-    id,
-    type: "started",
-    infoHash: torrent.infoHash || hash || null,
-    magnetURI: torrent.magnetURI,
-    mode,
-  });
 }
+
+async function addTorrent(id, { magnetUri, announce, mode }) {
+  if (!client) {
+    send({ id, error: "Client not initialized" });
+    return;
+  }
+  const hash = extractHash(magnetUri);
+  console.log(`[BT-Worker] ${mode} requested. Hash: ${hash}, Trackers: ${(announce || []).length}`);
+
+  if (hash) {
+    const existing = await client.get(hash);
+    if (existing && existing.infoHash) {
+      torrentModes.set(existing.infoHash, mode);
+      if (mode === "seed" && existing.done && !seedingStartedAt.has(existing.infoHash)) {
+        seedingStartedAt.set(existing.infoHash, Date.now());
+      }
+      send({
+        id, type: "started", infoHash: existing.infoHash,
+        magnetURI: existing.magnetURI, name: existing.name, mode,
+      });
+      return;
+    }
+  }
+
+  const torrent = client.add(magnetUri, { path: downloadPath, announce: announce || [] });
+  if (hash) torrentModes.set(hash, mode);
+  attachTorrentEvents(torrent, mode);
+
+  send({ id, type: "started", infoHash: torrent.infoHash || hash || null, magnetURI: torrent.magnetURI, mode });
+}
+
+function handleStart(id, params) { return addTorrent(id, { ...params, mode: "download" }); }
+function handleSeed(id, params) { return addTorrent(id, { ...params, mode: "seed" }); }
 
 async function handlePause(id, { hash }) {
   const torrent = hash ? await client.get(hash) : client.torrents[0];
-  if (!torrent) {
-    send({ id, error: "Torrent not found" });
-    return;
-  }
-  // torrent.pause() only stops new peer connections per WebTorrent docs,
-  // so we also choke all wires and deselect pieces to stop active transfers.
+  if (!torrent) return send({ id, error: "Torrent not found" });
   torrent.pause();
-  if (torrent.wires) {
-    torrent.wires.forEach((wire) => wire.choke());
-  }
-  torrent.deselect(0, torrent.pieces.length - 1, 0);
-  console.log(`[BT-Worker] Paused torrent: ${torrent.infoHash}`);
+  if (torrent.wires) torrent.wires.forEach((w) => w.choke());
+  if (torrent.pieces) torrent.deselect(0, torrent.pieces.length - 1, 0);
+  console.log(`[BT-Worker] Paused: ${torrent.infoHash}`);
   send({ id, type: "paused", infoHash: torrent.infoHash });
 }
 
 async function handleResume(id, { hash }) {
   const torrent = hash ? await client.get(hash) : client.torrents[0];
-  if (!torrent) {
-    send({ id, error: "Torrent not found" });
-    return;
-  }
+  if (!torrent) return send({ id, error: "Torrent not found" });
   torrent.resume();
-  // Re-select all files and unchoke wires to restart transfers
-  if (torrent.files) {
-    torrent.files.forEach((file) => file.select());
-  }
-  if (torrent.wires) {
-    torrent.wires.forEach((wire) => wire.unchoke());
-  }
-  console.log(`[BT-Worker] Resumed torrent: ${torrent.infoHash}`);
+  if (torrent.files) torrent.files.forEach((f) => f.select());
+  if (torrent.wires) torrent.wires.forEach((w) => w.unchoke());
+  console.log(`[BT-Worker] Resumed: ${torrent.infoHash}`);
   send({ id, type: "resumed", infoHash: torrent.infoHash });
 }
 
 async function handleUnseed(id, { hash }) {
   const torrent = hash ? await client.get(hash) : client.torrents[0];
-  if (!torrent) {
-    send({ id, error: "Torrent not found" });
-    return;
-  }
+  if (!torrent) return send({ id, error: "Torrent not found" });
   const infoHash = torrent.infoHash;
-  torrentModes.set(infoHash, "download");
-  seedingStartedAt.delete(infoHash);
-  clearTorrentTracking(infoHash);
-  // End torrent session when leaving seed mode so it cannot resume uploads.
+  clearTracking(infoHash);
   torrent.destroy({ destroyStore: false }, () => {
     console.log(`[BT-Worker] Stopped seeding: ${infoHash}`);
     send({ id, type: "unseeded", infoHash });
-    void maybeUseDownloadProfileWhenIdle();
   });
 }
 
 async function handleStop(id, { hash }) {
   const torrent = hash ? await client.get(hash) : client.torrents[0];
-  if (!torrent) {
-    send({ id, error: "Torrent not found" });
-    return;
-  }
+  if (!torrent) return send({ id, error: "Torrent not found" });
+  const snapshot = buildStatus(torrent);
   const infoHash = torrent.infoHash;
-  const mode = torrentModes.get(infoHash) || "download";
-  const wasDone = !!torrent.done;
-  const name = torrent.name || "";
-  const magnetURI = torrent.magnetURI;
-  const uploaded = torrent.uploaded || 0;
-  const downloaded = torrent.downloaded || 0;
-  const ratio = torrent.ratio || 0;
-  const files = torrent.files
-    ? torrent.files.map((f, i) => ({
-        index: i,
-        name: f.name,
-        path: f.path,
-        length: f.length,
-        downloaded: f.downloaded,
-        progress: f.progress,
-      }))
-    : [];
-  clearTorrentTracking(infoHash);
+  clearTracking(infoHash);
   torrent.destroy({ destroyStore: false }, () => {
-    console.log(`[BT-Worker] Stopped torrent session: ${infoHash}`);
+    console.log(`[BT-Worker] Stopped: ${infoHash}`);
     send({
-      id,
-      type: "stopped",
-      infoHash,
-      name,
-      mode,
-      done: wasDone,
-      paused: true,
-      stopped: true,
-      isSeeding: false,
-      seedingSince: null,
-      downloadPath,
-      magnetURI,
-      uploaded,
-      downloaded,
-      downloadSpeed: 0,
-      uploadSpeed: 0,
-      numPeers: 0,
-      ratio,
-      timeRemaining: null,
-      files,
+      id, type: "stopped", ...snapshot,
+      paused: true, stopped: true, isSeeding: false, seedingSince: null,
+      downloadSpeed: 0, uploadSpeed: 0, numPeers: 0, timeRemaining: null,
     });
-    void maybeUseDownloadProfileWhenIdle();
   });
 }
 
 async function handleRemove(id, { hash }) {
   const torrent = hash ? await client.get(hash) : client.torrents[0];
-  if (!torrent) {
-    send({ id, error: "Torrent not found" });
-    return;
-  }
+  if (!torrent) return send({ id, error: "Torrent not found" });
   const infoHash = torrent.infoHash;
-  clearTorrentTracking(infoHash);
+  clearTracking(infoHash);
   torrent.destroy({ destroyStore: false }, () => {
-    console.log(`[BT-Worker] Removed torrent: ${infoHash}`);
+    console.log(`[BT-Worker] Removed: ${infoHash}`);
     send({ id, type: "removed", infoHash });
-    void maybeUseDownloadProfileWhenIdle();
   });
 }
 
-// Graceful shutdown
-process.on("SIGTERM", () => {
-  console.log("[BT-Worker] SIGTERM received, shutting down...");
-  if (client) {
-    client.destroy(() => {
-      process.exit(0);
-    });
-  } else {
-    process.exit(0);
-  }
-});
+function shutdown() {
+  console.log("[BT-Worker] Shutting down...");
+  const forceExit = setTimeout(() => process.exit(0), 3000);
+  forceExit.unref();
+  if (client) client.destroy(() => { clearTimeout(forceExit); process.exit(0); });
+  else { clearTimeout(forceExit); process.exit(0); }
+}
 
-process.on("disconnect", () => {
-  console.log("[BT-Worker] Parent disconnected, shutting down...");
-  if (client) {
-    client.destroy(() => {
-      process.exit(0);
-    });
-  } else {
-    process.exit(0);
-  }
-});
+process.on("SIGTERM", shutdown);
+process.on("disconnect", shutdown);


### PR DESCRIPTION
Fixes issues in #191, peer discovery failure (0 peers) introduced by #191's WebTorrent client config changes by reverting to proven settings and adding HTTP/HTTPS tracker fallbacks for UDP-blocked networks. Also fixes torrent state persistence across app restarts, orphaned worker processes, file deletion on remove, and a UI race condition on stop seeding.