### PR TITLE
fix: re-provide IPFS CIDs periodically and suppress DHT stack overflow

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,8 @@ import { getBrowserSession, usePersist } from "./session.js";
 import { setupPermissionHandler } from "./permissions.js";
 import { setupP2pmdPdfExportIpc } from "./pages/p2p/p2pmd/pdf-export-ipc.js";
 
+const log = createLogger('main');
+
 const P2P_PROTOCOL = {
   standard: true,
   secure: true,
@@ -77,8 +79,6 @@ const MAGNET_PROTOCOL = {
   bypassCSP: false,
   corsEnabled: true,
 };
-
-const log = createLogger('main');
 
 let windowManager = null;
 
@@ -870,5 +870,15 @@ ipcMain.handle('check-built-in-engine', (event, template) => {
 });
 
 setupP2pmdPdfExportIpc();
+
+// Suppress the libp2p/utils queue stack-overflow that fires when the
+// kad-DHT reprovider runs. Without this Electron shows a blocking dialog.
+process.on('uncaughtException', (error) => {
+  if (error instanceof RangeError && error.message === 'Maximum call stack size exceeded') {
+    log.warn('[main] Caught libp2p queue stack overflow (reprovider) — suppressed');
+    return;
+  }
+  log.error('[main] Uncaught exception:', error);
+});
 
 export { windowManager };

--- a/src/protocols/ipfs-handler.js
+++ b/src/protocols/ipfs-handler.js
@@ -99,6 +99,36 @@ export async function createHandler(ipfsOptions, session) {
 
   await initializeIPFSNode();
 
+  // Re-announce cached CIDs to the DHT every 6h so provider records
+  // don't expire (48h validity). The built-in reprovider crashes, so
+  // we do our own sequential loop here.
+  const REPROVIDE_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+  async function reprovideAllCids() {
+    if (!node || ipfsCache.length === 0) return;
+    log.info(`[IPFS] Starting periodic re-provide for ${ipfsCache.length} CID(s)`);
+    let provided = 0;
+    for (const entry of ipfsCache) {
+      try {
+        if (!entry.cid) continue;
+        const cid = CID.parse(entry.cid);
+        await node.libp2p.contentRouting.provide(cid, { signal: AbortSignal.timeout(30_000) });
+        provided++;
+      } catch (err) {
+        log.warn(`[IPFS] Re-provide failed for ${entry.cid}: ${err.message}`);
+      }
+      // Small delay between provides to avoid overwhelming the DHT
+      await new Promise(r => setTimeout(r, 2000));
+    }
+    log.info(`[IPFS] Re-provide complete: ${provided}/${ipfsCache.length} succeeded`);
+  }
+  setInterval(() => {
+    reprovideAllCids().catch(err => log.error('[IPFS] Re-provide loop error:', err.message));
+  }, REPROVIDE_INTERVAL_MS);
+  // Run first re-provide 2 minutes after startup (give DHT time to bootstrap)
+  setTimeout(() => {
+    reprovideAllCids().catch(err => log.error('[IPFS] Initial re-provide error:', err.message));
+  }, 2 * 60 * 1000);
+
   // Initialize Ethereum provider with configurable RPC URL
   const provider = new JsonRpcProvider(RPC_URL);
 


### PR DESCRIPTION
- Added a sequential re-provide loop that re-announces all cached CIDs to the DHT every 6 hours (first run 2 min after startup). This bypasses the buggy internal queue entirely.
- Catch the `uncaughtException` so the stack overflow doesn't surface as a blocking dialog.

<img width="632" height="145" alt="Screenshot 2026-05-02 at 11 50 28 AM" src="https://github.com/user-attachments/assets/74fcb418-8ff8-43b8-90ea-989bb984aafa" />
