### PR TITLE
test: add peer p2pmd ownership sync e2e for delete and whitespace churn

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "npm run test:all",
     "test:all": "npm run test:p2p && npm run test:p2p:e2e && npm run test:extensions && npm run test:security && npm run test:integration",
     "test:integration": "mocha \"test/integration/**/*.test.js\" --timeout 300000",
+    "test:p2pmd:gutter:e2e": "mocha \"test/integration/p2pmd-gutter-sync.e2e.test.js\" --timeout 300000 --exit",
     "test:p2p": "mocha \"test/p2p/ipfs-handler.test.js\" \"test/p2p/hyper-handler.test.js\" \"test/p2p/hs-handler.test.js\" \"test/p2p/bittorrent-handler.test.js\" --timeout 20000 --exit",
     "test:p2p:bt": "mocha \"test/p2p/bittorrent-handler.test.js\" --timeout 20000",
     "test:p2p:e2e": "rimraf .test-e2e-data && cross-env NODE_ENV=test PEERSKY_TEST_USERDATA=.test-e2e-data mocha --file ./test/setup.js \"test/p2p/p2p-e2e.test.js\" --timeout 120000 --exit",

--- a/test/integration/p2pmd-gutter-sync-harness.mjs
+++ b/test/integration/p2pmd-gutter-sync-harness.mjs
@@ -1,0 +1,492 @@
+import path from "path";
+import os from "os";
+import fs from "fs/promises";
+import electron from "electron";
+
+const { app, BrowserWindow } = electron;
+
+const RESULT_PREFIX = "__PEERSKY_RESULT__";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (key && key.startsWith("--") && value !== undefined) {
+      args[key.slice(2)] = value;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+const cliArgs = parseArgs(process.argv.slice(2));
+
+const ROOM_URL = cliArgs["room-url"] || "http://127.0.0.1:9999";
+const USER_DATA_ROOT = cliArgs["user-data"] || os.tmpdir();
+const TEST_KEY = "hs://0000e2eguttersynctestruntimekey000000000000000000000000";
+
+const BOOT_TIMEOUT_MS = 25_000;
+const EDITOR_READY_TIMEOUT_MS = 30_000;
+const BETWEEN_PASTE_MS = 1_600;
+const CONVERGENCE_TIMEOUT_MS = 40_000;
+
+const PEERS = [
+  { name: "person1", color: "#e53e3e", clientId: "e2e-peer-1", role: "host" },
+  { name: "person2", color: "#38a169", clientId: "e2e-peer-2", role: "client" },
+  { name: "person3", color: "#3182ce", clientId: "e2e-peer-3", role: "client" },
+];
+
+const PERSON1_BLOCK = "# person1\n- line1\n- line2\n- line3";
+const PERSON2_BLOCK = "# person2\n- line1\n- line2\n- line3";
+const PERSON3_BLOCK = "# person3\n- line1\n- line2\n- line3";
+const TOP_LINE_1 = "first line after block by person1";
+const TOP_LINE_2 = "second line after block by person 2";
+const TOP_LINE_3 = "third line after block by person 3";
+
+const EXPECTED_FINAL_TEXT =
+  "first line after block by person1\nsecond line after block by person 2\nthird line after block by person 3\n\n# person3\n- line1\n- line2\n- line3\n\n# person1\n- line1\n- line2\n- line3\n\n# person2\n- line1\n- line2\n- line3";
+
+function emitResult(payload) {
+  process.stdout.write(`${RESULT_PREFIX}${JSON.stringify(payload)}\n`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withTimeout(promise, timeoutMs, label) {
+  let timer = null;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function safeExec(win, code, label = "executeJavaScript", timeoutMs = 12_000) {
+  try {
+    return await withTimeout(win.webContents.executeJavaScript(code, true), timeoutMs, label);
+  } catch (error) {
+    return { __error: String(error?.message || error) };
+  }
+}
+
+async function waitForEditorReady(win) {
+  const started = Date.now();
+  while (Date.now() - started < EDITOR_READY_TIMEOUT_MS) {
+    const ready = await safeExec(
+      win,
+      `Boolean(document.getElementById("markdownInput")) && !document.getElementById("editor-page")?.classList.contains("hidden")`,
+      "waitForEditorReady"
+    );
+    if (ready === true) return true;
+    await sleep(500);
+  }
+  return false;
+}
+
+async function openPeerWindow(peer, index) {
+  const pagePath = path.resolve("src/pages/p2p/p2pmd/index.html");
+
+  const win = new BrowserWindow({
+    show: false,
+    width: 1280,
+    height: 900,
+    x: index * 80,
+    y: index * 80,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: false,
+      webSecurity: false,
+      allowRunningInsecureContent: true,
+      partition: `persist:p2pmd-e2e-${peer.clientId}`,
+    },
+  });
+
+  win.webContents.on("did-fail-load", (_e, code, desc, url) => {
+    console.error(`[harness] did-fail-load (${peer.name}) code=${code} desc=${desc} url=${url}`);
+  });
+
+  console.log(`[harness] opening ${peer.name}`);
+  await withTimeout(win.loadFile(pagePath), BOOT_TIMEOUT_MS, `loadFile(${peer.name})`);
+
+  await safeExec(
+    win,
+    `
+      localStorage.setItem("p2pmd-display-name", ${JSON.stringify(peer.name)});
+      localStorage.setItem("p2pmd-user-color", ${JSON.stringify(peer.color)});
+      localStorage.setItem("p2pmd-client-id", ${JSON.stringify(peer.clientId)});
+      const onboardingInput = document.getElementById("onboarding-name");
+      if (onboardingInput) onboardingInput.value = ${JSON.stringify(peer.name)};
+      true;
+    `,
+    `setIdentity(${peer.name})`
+  );
+
+  const roomPort = String(new URL(ROOM_URL).port || "");
+  await safeExec(
+    win,
+    `
+      (() => {
+        const originalFetch = window.fetch.bind(window);
+        window.fetch = async function(input, init) {
+          const raw = typeof input === "string" ? input : (input && input.url) || "";
+          if (raw.startsWith("hs://p2pmd")) {
+            const u = new URL(raw);
+            const action = u.searchParams.get("action") || "";
+            if (["join", "create", "rehost"].includes(action)) {
+              return new Response(JSON.stringify({
+                ok: true,
+                key: ${JSON.stringify(TEST_KEY)},
+                localUrl: ${JSON.stringify(ROOM_URL)},
+                localHost: "127.0.0.1",
+                localPort: ${JSON.stringify(roomPort)},
+                secure: false,
+                udp: false,
+              }), { status: 200, headers: { "Content-Type": "application/json" } });
+            }
+          }
+          return originalFetch(input, init);
+        };
+      })();
+      true;
+    `,
+    `patchFetch(${peer.name})`
+  );
+
+  await safeExec(
+    win,
+    `
+      (async () => {
+        const onboarding = document.getElementById("onboarding-page");
+        if (onboarding && !onboarding.classList.contains("hidden")) {
+          document.getElementById("onboard-submit")?.click();
+          await new Promise((r) => setTimeout(r, 400));
+        }
+        return true;
+      })();
+    `,
+    `onboarding(${peer.name})`
+  );
+
+  await safeExec(
+    win,
+    `
+      (() => {
+        const joinInput = document.getElementById("join-room-key");
+        const joinForm = document.getElementById("join-form");
+        if (!joinInput || !joinForm) return { ok: false, reason: "join controls missing" };
+        joinInput.value = ${JSON.stringify(TEST_KEY)};
+        joinForm.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+        return { ok: true };
+      })();
+    `,
+    `joinSubmit(${peer.name})`
+  );
+
+  const editorReady = await waitForEditorReady(win);
+  if (!editorReady) {
+    throw new Error(`Editor did not become ready for ${peer.name}`);
+  }
+
+  return win;
+}
+
+async function pasteBlock(win, block, prepend) {
+  return safeExec(
+    win,
+    `
+      (() => {
+        const ta = document.getElementById("markdownInput");
+        if (!ta) return { ok: false, reason: "markdownInput missing" };
+        const current = ta.value || "";
+        const block = ${JSON.stringify(block)};
+        const next = ${prepend}
+          ? (current ? (block + "\\n\\n" + current) : block)
+          : (current ? (current + "\\n\\n" + block) : block);
+        ta.value = next;
+        ta.dispatchEvent(new Event("input", { bubbles: true }));
+        return { ok: true, length: next.length };
+      })();
+    `,
+    "pasteBlock"
+  );
+}
+
+async function insertTopLineAtIndex(win, lineText, index, ensureBlankAfterTop = false) {
+  return safeExec(
+    win,
+    `
+      (() => {
+        const ta = document.getElementById("markdownInput");
+        if (!ta) return { ok: false, reason: "markdownInput missing" };
+        const current = ta.value || "";
+        const lines = current.length > 0 ? current.split("\\n") : [];
+        const idx = Math.max(0, Math.min(${index}, lines.length));
+        lines.splice(idx, 0, ${JSON.stringify(lineText)});
+        if (${ensureBlankAfterTop ? "true" : "false"}) {
+          const topCount = idx + 1;
+          if (lines[topCount] !== "") {
+            lines.splice(topCount, 0, "");
+          }
+        }
+        const next = lines.join("\\n");
+        ta.value = next;
+        ta.dispatchEvent(new Event("input", { bubbles: true }));
+        return { ok: true, length: next.length };
+      })();
+    `,
+    "insertTopLineAtIndex"
+  );
+}
+
+async function getText(win) {
+  return safeExec(win, `document.getElementById("markdownInput")?.value || ""`, "getText");
+}
+
+async function getGutterMarks(win) {
+  return safeExec(
+    win,
+    `
+      (() => {
+        const gutter = document.getElementById("author-gutter");
+        const ta = document.getElementById("markdownInput");
+        if (!gutter || !ta) return { marks: [], metrics: null };
+        const cs = window.getComputedStyle(ta);
+        const lineHeight = parseFloat(cs.lineHeight) || 20;
+        const paddingTop = parseFloat(cs.paddingTop) || 0;
+        const marks = Array.from(gutter.querySelectorAll(".author-gutter-mark")).map((el) => {
+          const style = el.style;
+          return {
+            top: parseFloat(style.top) || 0,
+            height: parseFloat(style.height) || 0,
+            color: style.getPropertyValue("--peer-color") || style.background || "",
+            name: el.dataset.peerName || "",
+          };
+        });
+        return {
+          marks,
+          metrics: {
+            lineHeight,
+            paddingTop,
+            scrollTop: ta.scrollTop || 0
+          }
+        };
+      })();
+    `,
+    "getGutterMarks"
+  );
+}
+
+function computeGaps(marks) {
+  if (!Array.isArray(marks) || marks.length < 2) return [];
+  const sorted = [...marks].sort((a, b) => a.top - b.top);
+  const gaps = [];
+  for (let i = 1; i < sorted.length; i += 1) {
+    const prevEnd = sorted[i - 1].top + sorted[i - 1].height;
+    const gap = sorted[i].top - prevEnd;
+    if (gap > 2) gaps.push(Math.round(gap));
+  }
+  return gaps;
+}
+
+function distinctNames(marks) {
+  return Array.from(
+    new Set(
+      (marks || [])
+        .map((m) => (m.name || "").trim())
+        .filter(Boolean)
+    )
+  );
+}
+
+function distinctAuthorTokens(marks) {
+  return Array.from(
+    new Set(
+      (marks || [])
+        .map((m) => `${(m.color || "").trim()}|${(m.name || "").trim()}`)
+        .filter((token) => token.split("|")[0])
+    )
+  );
+}
+
+function computeLineOwners(text, marks, metrics) {
+  const content = typeof text === "string" ? text : "";
+  const lineCount = (content.match(/\n/g) || []).length + 1;
+  const sorted = [...(marks || [])].sort((a, b) => a.top - b.top);
+  const lineHeight = Number(metrics?.lineHeight) || 20;
+  const paddingTop = Number(metrics?.paddingTop) || 0;
+  const scrollTop = Number(metrics?.scrollTop) || 0;
+
+  const owners = [];
+  for (let line = 1; line <= lineCount; line += 1) {
+    const yCenter = paddingTop - scrollTop + ((line - 1) * lineHeight) + (lineHeight / 2);
+    const mark = sorted.find((m) => yCenter >= m.top && yCenter <= (m.top + m.height));
+    owners.push({
+      line,
+      text: (content.split("\n")[line - 1] ?? ""),
+      name: mark?.name || null,
+      color: mark?.color || null,
+      token: mark ? `${mark.color || ""}|${mark.name || ""}` : null
+    });
+  }
+  return owners;
+}
+
+async function captureScreenshot(win, screenshotDir, name) {
+  try {
+    const image = await win.webContents.capturePage();
+    const target = path.join(screenshotDir, name);
+    await fs.writeFile(target, image.toPNG());
+    return target;
+  } catch {
+    return null;
+  }
+}
+
+async function waitForConvergence(windows, expectedText) {
+  const started = Date.now();
+  while (Date.now() - started < CONVERGENCE_TIMEOUT_MS) {
+    const texts = await Promise.all(windows.map((w) => getText(w)));
+    const normalized = texts.map((v) => (typeof v === "string" ? v.trim() : ""));
+    if (normalized.every((t) => t === expectedText.trim())) {
+      return { converged: true, texts };
+    }
+    await sleep(800);
+  }
+  const texts = await Promise.all(windows.map((w) => getText(w)));
+  return { converged: false, texts };
+}
+
+app.commandLine.appendSwitch("disable-gpu");
+app.commandLine.appendSwitch("no-sandbox");
+app.commandLine.appendSwitch("disable-web-security");
+
+if (USER_DATA_ROOT) {
+  app.setPath("userData", path.resolve(USER_DATA_ROOT));
+}
+
+app.whenReady().then(async () => {
+  const screenshotDir = path.join(USER_DATA_ROOT, "screenshots");
+  await fs.mkdir(screenshotDir, { recursive: true });
+
+  const windows = [];
+
+  try {
+    console.log("[harness] Opening peer windows...");
+
+    const w1 = await openPeerWindow(PEERS[0], 0);
+    windows.push(w1);
+    await sleep(1_200);
+
+    const w2 = await openPeerWindow(PEERS[1], 1);
+    windows.push(w2);
+    await sleep(1_000);
+
+    const w3 = await openPeerWindow(PEERS[2], 2);
+    windows.push(w3);
+    await sleep(1_500);
+
+    console.log("[harness] person1 paste");
+    await pasteBlock(w1, PERSON1_BLOCK, false);
+    await sleep(BETWEEN_PASTE_MS);
+
+    console.log("[harness] person2 paste");
+    await pasteBlock(w2, PERSON2_BLOCK, false);
+    await sleep(BETWEEN_PASTE_MS);
+
+    console.log("[harness] person3 paste (prepend)");
+    await pasteBlock(w3, PERSON3_BLOCK, true);
+    await sleep(BETWEEN_PASTE_MS);
+
+    console.log("[harness] person1 top line");
+    await insertTopLineAtIndex(w1, TOP_LINE_1, 0, false);
+    await sleep(BETWEEN_PASTE_MS);
+
+    console.log("[harness] person2 top line");
+    await insertTopLineAtIndex(w2, TOP_LINE_2, 1, false);
+    await sleep(BETWEEN_PASTE_MS);
+
+    console.log("[harness] person3 top line");
+    await insertTopLineAtIndex(w3, TOP_LINE_3, 2, true);
+    await sleep(BETWEEN_PASTE_MS);
+
+    console.log("[harness] waiting for convergence");
+    const { converged, texts } = await waitForConvergence(windows, EXPECTED_FINAL_TEXT);
+
+    await sleep(2_000);
+
+    const instances = [];
+    for (let i = 0; i < windows.length; i += 1) {
+      const peer = PEERS[i];
+      const win = windows[i];
+      const rawText = typeof texts[i] === "string" ? texts[i] : await getText(win);
+      const gutter = await getGutterMarks(win);
+      const marks = Array.isArray(gutter?.marks) ? gutter.marks : [];
+      const metrics = gutter?.metrics || null;
+      const names = distinctNames(marks);
+      const tokens = distinctAuthorTokens(marks);
+      const lineOwners = computeLineOwners(rawText, marks, metrics);
+
+      const screenshotPath = await captureScreenshot(win, screenshotDir, `${peer.name}.png`);
+
+      instances.push({
+        name: peer.name,
+        role: peer.role,
+        text: typeof rawText === "string" ? rawText : "",
+        converged: typeof rawText === "string" && rawText.trim() === EXPECTED_FINAL_TEXT.trim(),
+        markCount: marks.length,
+        marks,
+        metrics,
+        lineOwners,
+        distinctAuthorNames: names,
+        distinctAuthorTokens: tokens,
+        distinctAuthors: tokens.length,
+        gutterGaps: computeGaps(marks),
+        screenshotPath,
+      });
+    }
+
+    emitResult({ ok: true, converged, expectedFinalText: EXPECTED_FINAL_TEXT, instances });
+    app.exit(0);
+  } catch (error) {
+    const instances = [];
+    for (let i = 0; i < windows.length; i += 1) {
+      const peer = PEERS[i];
+      const win = windows[i];
+      const text = await getText(win).catch(() => "");
+      const gutter = await getGutterMarks(win).catch(() => ({ marks: [] }));
+      const marks = Array.isArray(gutter?.marks) ? gutter.marks : [];
+      const metrics = gutter?.metrics || null;
+      const screenshotPath = await captureScreenshot(win, screenshotDir, `${peer.name}-error.png`).catch(() => null);
+      instances.push({
+        name: peer.name,
+        role: peer.role,
+        text: typeof text === "string" ? text : "",
+        markCount: marks.length,
+        marks,
+        metrics,
+        lineOwners: computeLineOwners(text, marks, metrics),
+        distinctAuthorNames: distinctNames(marks),
+        distinctAuthorTokens: distinctAuthorTokens(marks),
+        distinctAuthors: distinctAuthorTokens(marks).length,
+        gutterGaps: computeGaps(marks),
+        screenshotPath,
+      });
+    }
+
+    emitResult({ ok: false, error: String(error?.message || error), instances });
+    app.exit(1);
+  } finally {
+    for (const win of windows) {
+      try {
+        if (win && !win.isDestroyed()) win.destroy();
+      } catch {
+      }
+    }
+  }
+});

--- a/test/integration/p2pmd-gutter-sync-harness.mjs
+++ b/test/integration/p2pmd-gutter-sync-harness.mjs
@@ -1,98 +1,98 @@
-import path from "path";
-import os from "os";
-import fs from "fs/promises";
-import electron from "electron";
+import path from 'path'
+import os from 'os'
+import fs from 'fs/promises'
+import electron from 'electron'
 
-const { app, BrowserWindow } = electron;
+const { app, BrowserWindow } = electron
 
-const RESULT_PREFIX = "__PEERSKY_RESULT__";
+const RESULT_PREFIX = '__PEERSKY_RESULT__'
 
-function parseArgs(argv) {
-  const args = {};
+function parseArgs (argv) {
+  const args = {}
   for (let i = 0; i < argv.length; i += 1) {
-    const key = argv[i];
-    const value = argv[i + 1];
-    if (key && key.startsWith("--") && value !== undefined) {
-      args[key.slice(2)] = value;
-      i += 1;
+    const key = argv[i]
+    const value = argv[i + 1]
+    if (key && key.startsWith('--') && value !== undefined) {
+      args[key.slice(2)] = value
+      i += 1
     }
   }
-  return args;
+  return args
 }
 
-const cliArgs = parseArgs(process.argv.slice(2));
+const cliArgs = parseArgs(process.argv.slice(2))
 
-const ROOM_URL = cliArgs["room-url"] || "http://127.0.0.1:9999";
-const USER_DATA_ROOT = cliArgs["user-data"] || os.tmpdir();
-const TEST_KEY = "hs://0000e2eguttersynctestruntimekey000000000000000000000000";
+const ROOM_URL = cliArgs['room-url'] || 'http://127.0.0.1:9999'
+const USER_DATA_ROOT = cliArgs['user-data'] || os.tmpdir()
+const TEST_KEY = 'hs://0000e2eguttersynctestruntimekey000000000000000000000000'
 
-const BOOT_TIMEOUT_MS = 25_000;
-const EDITOR_READY_TIMEOUT_MS = 30_000;
-const BETWEEN_PASTE_MS = 1_600;
-const CONVERGENCE_TIMEOUT_MS = 40_000;
+const BOOT_TIMEOUT_MS = 25_000
+const EDITOR_READY_TIMEOUT_MS = 30_000
+const BETWEEN_PASTE_MS = 1_600
+const CONVERGENCE_TIMEOUT_MS = 40_000
 
 const PEERS = [
-  { name: "person1", color: "#e53e3e", clientId: "e2e-peer-1", role: "host" },
-  { name: "person2", color: "#38a169", clientId: "e2e-peer-2", role: "client" },
-  { name: "person3", color: "#3182ce", clientId: "e2e-peer-3", role: "client" },
-];
+  { name: 'person1', color: '#e53e3e', clientId: 'e2e-peer-1', role: 'host' },
+  { name: 'person2', color: '#38a169', clientId: 'e2e-peer-2', role: 'client' },
+  { name: 'person3', color: '#3182ce', clientId: 'e2e-peer-3', role: 'client' }
+]
 
-const PERSON1_BLOCK = "# person1\n- line1\n- line2\n- line3";
-const PERSON2_BLOCK = "# person2\n- line1\n- line2\n- line3";
-const PERSON3_BLOCK = "# person3\n- line1\n- line2\n- line3";
-const TOP_LINE_1 = "first line after block by person1";
-const TOP_LINE_2 = "second line after block by person 2";
-const TOP_LINE_3 = "third line after block by person 3";
-const PERSON3_EXTRA_BLANK_COUNT = 6;
-const TRAILING_SPACES_COUNT = 6;
+const PERSON1_BLOCK = '# person1\n- line1\n- line2\n- line3'
+const PERSON2_BLOCK = '# person2\n- line1\n- line2\n- line3'
+const PERSON3_BLOCK = '# person3\n- line1\n- line2\n- line3'
+const TOP_LINE_1 = 'first line after block by person1'
+const TOP_LINE_2 = 'second line after block by person 2'
+const TOP_LINE_3 = 'third line after block by person 3'
+const PERSON3_EXTRA_BLANK_COUNT = 6
+const TRAILING_SPACES_COUNT = 6
 
 const EXPECTED_FINAL_TEXT =
-  "second line after block by person 2\nthird line after block by person 3\n\n# person3\n- line1\n- line2\n- line3\n\n# person1\n- line1\n- line2\n- line3\n\n# person2\n- line1\n- line2\n- line3";
+  'second line after block by person 2\nthird line after block by person 3\n\n# person3\n- line1\n- line2\n- line3\n\n# person1\n- line1\n- line2\n- line3\n\n# person2\n- line1\n- line2\n- line3'
 
-function emitResult(payload) {
-  process.stdout.write(`${RESULT_PREFIX}${JSON.stringify(payload)}\n`);
+function emitResult (payload) {
+  process.stdout.write(`${RESULT_PREFIX}${JSON.stringify(payload)}\n`)
 }
 
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep (ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-async function withTimeout(promise, timeoutMs, label) {
-  let timer = null;
-  const timeout = new Promise((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
-  });
+async function withTimeout (promise, timeoutMs, label) {
+  let timer = null
+  const timeout = new Promise((resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs)
+  })
   try {
-    return await Promise.race([promise, timeout]);
+    return await Promise.race([promise, timeout])
   } finally {
-    if (timer) clearTimeout(timer);
+    if (timer) clearTimeout(timer)
   }
 }
 
-async function safeExec(win, code, label = "executeJavaScript", timeoutMs = 12_000) {
+async function safeExec (win, code, label = 'executeJavaScript', timeoutMs = 12_000) {
   try {
-    return await withTimeout(win.webContents.executeJavaScript(code, true), timeoutMs, label);
+    return await withTimeout(win.webContents.executeJavaScript(code, true), timeoutMs, label)
   } catch (error) {
-    return { __error: String(error?.message || error) };
+    return { __error: String(error?.message || error) }
   }
 }
 
-async function waitForEditorReady(win) {
-  const started = Date.now();
+async function waitForEditorReady (win) {
+  const started = Date.now()
   while (Date.now() - started < EDITOR_READY_TIMEOUT_MS) {
     const ready = await safeExec(
       win,
-      `Boolean(document.getElementById("markdownInput")) && !document.getElementById("editor-page")?.classList.contains("hidden")`,
-      "waitForEditorReady"
-    );
-    if (ready === true) return true;
-    await sleep(500);
+      'Boolean(document.getElementById("markdownInput")) && !document.getElementById("editor-page")?.classList.contains("hidden")',
+      'waitForEditorReady'
+    )
+    if (ready === true) return true
+    await sleep(500)
   }
-  return false;
+  return false
 }
 
-async function openPeerWindow(peer, index) {
-  const pagePath = path.resolve("src/pages/p2p/p2pmd/index.html");
+async function openPeerWindow (peer, index) {
+  const pagePath = path.resolve('src/pages/p2p/p2pmd/index.html')
 
   const win = new BrowserWindow({
     show: false,
@@ -105,16 +105,16 @@ async function openPeerWindow(peer, index) {
       contextIsolation: false,
       webSecurity: false,
       allowRunningInsecureContent: true,
-      partition: `persist:p2pmd-e2e-${peer.clientId}`,
-    },
-  });
+      partition: `persist:p2pmd-e2e-${peer.clientId}`
+    }
+  })
 
-  win.webContents.on("did-fail-load", (_e, code, desc, url) => {
-    console.error(`[harness] did-fail-load (${peer.name}) code=${code} desc=${desc} url=${url}`);
-  });
+  win.webContents.on('did-fail-load', (_e, code, desc, url) => {
+    console.error(`[harness] did-fail-load (${peer.name}) code=${code} desc=${desc} url=${url}`)
+  })
 
-  console.log(`[harness] opening ${peer.name}`);
-  await withTimeout(win.loadFile(pagePath), BOOT_TIMEOUT_MS, `loadFile(${peer.name})`);
+  console.log(`[harness] opening ${peer.name}`)
+  await withTimeout(win.loadFile(pagePath), BOOT_TIMEOUT_MS, `loadFile(${peer.name})`)
 
   await safeExec(
     win,
@@ -127,9 +127,9 @@ async function openPeerWindow(peer, index) {
       true;
     `,
     `setIdentity(${peer.name})`
-  );
+  )
 
-  const roomPort = String(new URL(ROOM_URL).port || "");
+  const roomPort = String(new URL(ROOM_URL).port || '')
   await safeExec(
     win,
     `
@@ -158,7 +158,7 @@ async function openPeerWindow(peer, index) {
       true;
     `,
     `patchFetch(${peer.name})`
-  );
+  )
 
   await safeExec(
     win,
@@ -173,7 +173,7 @@ async function openPeerWindow(peer, index) {
       })();
     `,
     `onboarding(${peer.name})`
-  );
+  )
 
   await safeExec(
     win,
@@ -188,17 +188,17 @@ async function openPeerWindow(peer, index) {
       })();
     `,
     `joinSubmit(${peer.name})`
-  );
+  )
 
-  const editorReady = await waitForEditorReady(win);
+  const editorReady = await waitForEditorReady(win)
   if (!editorReady) {
-    throw new Error(`Editor did not become ready for ${peer.name}`);
+    throw new Error(`Editor did not become ready for ${peer.name}`)
   }
 
-  return win;
+  return win
 }
 
-async function pasteBlock(win, block, prepend) {
+async function pasteBlock (win, block, prepend) {
   return safeExec(
     win,
     `
@@ -215,11 +215,11 @@ async function pasteBlock(win, block, prepend) {
         return { ok: true, length: next.length };
       })();
     `,
-    "pasteBlock"
-  );
+    'pasteBlock'
+  )
 }
 
-async function insertTopLineAtIndex(win, lineText, index, ensureBlankAfterTop = false) {
+async function insertTopLineAtIndex (win, lineText, index, ensureBlankAfterTop = false) {
   return safeExec(
     win,
     `
@@ -230,7 +230,7 @@ async function insertTopLineAtIndex(win, lineText, index, ensureBlankAfterTop = 
         const lines = current.length > 0 ? current.split("\\n") : [];
         const idx = Math.max(0, Math.min(${index}, lines.length));
         lines.splice(idx, 0, ${JSON.stringify(lineText)});
-        if (${ensureBlankAfterTop ? "true" : "false"}) {
+        if (${ensureBlankAfterTop ? 'true' : 'false'}) {
           const topCount = idx + 1;
           if (lines[topCount] !== "") {
             lines.splice(topCount, 0, "");
@@ -242,11 +242,11 @@ async function insertTopLineAtIndex(win, lineText, index, ensureBlankAfterTop = 
         return { ok: true, length: next.length };
       })();
     `,
-    "insertTopLineAtIndex"
-  );
+    'insertTopLineAtIndex'
+  )
 }
 
-async function deleteLineAtIndex(win, index) {
+async function deleteLineAtIndex (win, index) {
   return safeExec(
     win,
     `
@@ -264,11 +264,11 @@ async function deleteLineAtIndex(win, index) {
         return { ok: true, length: next.length };
       })();
     `,
-    "deleteLineAtIndex"
-  );
+    'deleteLineAtIndex'
+  )
 }
 
-async function insertBlankLinesAfterPerson3Block(win, blankCount = PERSON3_EXTRA_BLANK_COUNT) {
+async function insertBlankLinesAfterPerson3Block (win, blankCount = PERSON3_EXTRA_BLANK_COUNT) {
   return safeExec(
     win,
     `
@@ -287,11 +287,11 @@ async function insertBlankLinesAfterPerson3Block(win, blankCount = PERSON3_EXTRA
         return { ok: true, length: next.length };
       })();
     `,
-    "insertBlankLinesAfterPerson3Block"
-  );
+    'insertBlankLinesAfterPerson3Block'
+  )
 }
 
-async function removeBlankLinesAfterPerson3Block(win, blankCount = PERSON3_EXTRA_BLANK_COUNT) {
+async function removeBlankLinesAfterPerson3Block (win, blankCount = PERSON3_EXTRA_BLANK_COUNT) {
   return safeExec(
     win,
     `
@@ -309,11 +309,11 @@ async function removeBlankLinesAfterPerson3Block(win, blankCount = PERSON3_EXTRA
         return { ok: true, length: next.length };
       })();
     `,
-    "removeBlankLinesAfterPerson3Block"
-  );
+    'removeBlankLinesAfterPerson3Block'
+  )
 }
 
-async function addTrailingSpacesToTopLine3(win, spacesCount = TRAILING_SPACES_COUNT) {
+async function addTrailingSpacesToTopLine3 (win, spacesCount = TRAILING_SPACES_COUNT) {
   return safeExec(
     win,
     `
@@ -332,11 +332,11 @@ async function addTrailingSpacesToTopLine3(win, spacesCount = TRAILING_SPACES_CO
         return { ok: true, length: next.length };
       })();
     `,
-    "addTrailingSpacesToTopLine3"
-  );
+    'addTrailingSpacesToTopLine3'
+  )
 }
 
-async function removeTrailingSpacesFromTopLine3(win) {
+async function removeTrailingSpacesFromTopLine3 (win) {
   return safeExec(
     win,
     `
@@ -355,15 +355,15 @@ async function removeTrailingSpacesFromTopLine3(win) {
         return { ok: true, length: next.length };
       })();
     `,
-    "removeTrailingSpacesFromTopLine3"
-  );
+    'removeTrailingSpacesFromTopLine3'
+  )
 }
 
-async function getText(win) {
-  return safeExec(win, `document.getElementById("markdownInput")?.value || ""`, "getText");
+async function getText (win) {
+  return safeExec(win, 'document.getElementById("markdownInput")?.value || ""', 'getText')
 }
 
-async function getGutterMarks(win) {
+async function getGutterMarks (win) {
   return safeExec(
     win,
     `
@@ -393,187 +393,187 @@ async function getGutterMarks(win) {
         };
       })();
     `,
-    "getGutterMarks"
-  );
+    'getGutterMarks'
+  )
 }
 
-function computeGaps(marks) {
-  if (!Array.isArray(marks) || marks.length < 2) return [];
-  const sorted = [...marks].sort((a, b) => a.top - b.top);
-  const gaps = [];
+function computeGaps (marks) {
+  if (!Array.isArray(marks) || marks.length < 2) return []
+  const sorted = [...marks].sort((a, b) => a.top - b.top)
+  const gaps = []
   for (let i = 1; i < sorted.length; i += 1) {
-    const prevEnd = sorted[i - 1].top + sorted[i - 1].height;
-    const gap = sorted[i].top - prevEnd;
-    if (gap > 2) gaps.push(Math.round(gap));
+    const prevEnd = sorted[i - 1].top + sorted[i - 1].height
+    const gap = sorted[i].top - prevEnd
+    if (gap > 2) gaps.push(Math.round(gap))
   }
-  return gaps;
+  return gaps
 }
 
-function distinctNames(marks) {
+function distinctNames (marks) {
   return Array.from(
     new Set(
       (marks || [])
-        .map((m) => (m.name || "").trim())
+        .map((m) => (m.name || '').trim())
         .filter(Boolean)
     )
-  );
+  )
 }
 
-function distinctAuthorTokens(marks) {
+function distinctAuthorTokens (marks) {
   return Array.from(
     new Set(
       (marks || [])
-        .map((m) => `${(m.color || "").trim()}|${(m.name || "").trim()}`)
-        .filter((token) => token.split("|")[0])
+        .map((m) => `${(m.color || '').trim()}|${(m.name || '').trim()}`)
+        .filter((token) => token.split('|')[0])
     )
-  );
+  )
 }
 
-function computeLineOwners(text, marks, metrics) {
-  const content = typeof text === "string" ? text : "";
-  const lineCount = (content.match(/\n/g) || []).length + 1;
-  const sorted = [...(marks || [])].sort((a, b) => a.top - b.top);
-  const lineHeight = Number(metrics?.lineHeight) || 20;
-  const paddingTop = Number(metrics?.paddingTop) || 0;
-  const scrollTop = Number(metrics?.scrollTop) || 0;
+function computeLineOwners (text, marks, metrics) {
+  const content = typeof text === 'string' ? text : ''
+  const lineCount = (content.match(/\n/g) || []).length + 1
+  const sorted = [...(marks || [])].sort((a, b) => a.top - b.top)
+  const lineHeight = Number(metrics?.lineHeight) || 20
+  const paddingTop = Number(metrics?.paddingTop) || 0
+  const scrollTop = Number(metrics?.scrollTop) || 0
 
-  const owners = [];
+  const owners = []
   for (let line = 1; line <= lineCount; line += 1) {
-    const yCenter = paddingTop - scrollTop + ((line - 1) * lineHeight) + (lineHeight / 2);
-    const mark = sorted.find((m) => yCenter >= m.top && yCenter <= (m.top + m.height));
+    const yCenter = paddingTop - scrollTop + ((line - 1) * lineHeight) + (lineHeight / 2)
+    const mark = sorted.find((m) => yCenter >= m.top && yCenter <= (m.top + m.height))
     owners.push({
       line,
-      text: (content.split("\n")[line - 1] ?? ""),
+      text: (content.split('\n')[line - 1] ?? ''),
       name: mark?.name || null,
       color: mark?.color || null,
-      token: mark ? `${mark.color || ""}|${mark.name || ""}` : null
-    });
+      token: mark ? `${mark.color || ''}|${mark.name || ''}` : null
+    })
   }
-  return owners;
+  return owners
 }
 
-async function captureScreenshot(win, screenshotDir, name) {
+async function captureScreenshot (win, screenshotDir, name) {
   try {
-    const image = await win.webContents.capturePage();
-    const target = path.join(screenshotDir, name);
-    await fs.writeFile(target, image.toPNG());
-    return target;
+    const image = await win.webContents.capturePage()
+    const target = path.join(screenshotDir, name)
+    await fs.writeFile(target, image.toPNG())
+    return target
   } catch {
-    return null;
+    return null
   }
 }
 
-async function waitForConvergence(windows, expectedText) {
-  const started = Date.now();
+async function waitForConvergence (windows, expectedText) {
+  const started = Date.now()
   while (Date.now() - started < CONVERGENCE_TIMEOUT_MS) {
-    const texts = await Promise.all(windows.map((w) => getText(w)));
-    const normalized = texts.map((v) => (typeof v === "string" ? v.trim() : ""));
+    const texts = await Promise.all(windows.map((w) => getText(w)))
+    const normalized = texts.map((v) => (typeof v === 'string' ? v.trim() : ''))
     if (normalized.every((t) => t === expectedText.trim())) {
-      return { converged: true, texts };
+      return { converged: true, texts }
     }
-    await sleep(800);
+    await sleep(800)
   }
-  const texts = await Promise.all(windows.map((w) => getText(w)));
-  return { converged: false, texts };
+  const texts = await Promise.all(windows.map((w) => getText(w)))
+  return { converged: false, texts }
 }
 
-app.commandLine.appendSwitch("disable-gpu");
-app.commandLine.appendSwitch("no-sandbox");
-app.commandLine.appendSwitch("disable-web-security");
+app.commandLine.appendSwitch('disable-gpu')
+app.commandLine.appendSwitch('no-sandbox')
+app.commandLine.appendSwitch('disable-web-security')
 
 if (USER_DATA_ROOT) {
-  app.setPath("userData", path.resolve(USER_DATA_ROOT));
+  app.setPath('userData', path.resolve(USER_DATA_ROOT))
 }
 
 app.whenReady().then(async () => {
-  const screenshotDir = path.join(USER_DATA_ROOT, "screenshots");
-  await fs.mkdir(screenshotDir, { recursive: true });
+  const screenshotDir = path.join(USER_DATA_ROOT, 'screenshots')
+  await fs.mkdir(screenshotDir, { recursive: true })
 
-  const windows = [];
+  const windows = []
 
   try {
-    console.log("[harness] Opening peer windows...");
+    console.log('[harness] Opening peer windows...')
 
-    const w1 = await openPeerWindow(PEERS[0], 0);
-    windows.push(w1);
-    await sleep(1_200);
+    const w1 = await openPeerWindow(PEERS[0], 0)
+    windows.push(w1)
+    await sleep(1_200)
 
-    const w2 = await openPeerWindow(PEERS[1], 1);
-    windows.push(w2);
-    await sleep(1_000);
+    const w2 = await openPeerWindow(PEERS[1], 1)
+    windows.push(w2)
+    await sleep(1_000)
 
-    const w3 = await openPeerWindow(PEERS[2], 2);
-    windows.push(w3);
-    await sleep(1_500);
+    const w3 = await openPeerWindow(PEERS[2], 2)
+    windows.push(w3)
+    await sleep(1_500)
 
-    console.log("[harness] person1 paste");
-    await pasteBlock(w1, PERSON1_BLOCK, false);
-    await sleep(BETWEEN_PASTE_MS);
+    console.log('[harness] person1 paste')
+    await pasteBlock(w1, PERSON1_BLOCK, false)
+    await sleep(BETWEEN_PASTE_MS)
 
-    console.log("[harness] person2 paste");
-    await pasteBlock(w2, PERSON2_BLOCK, false);
-    await sleep(BETWEEN_PASTE_MS);
+    console.log('[harness] person2 paste')
+    await pasteBlock(w2, PERSON2_BLOCK, false)
+    await sleep(BETWEEN_PASTE_MS)
 
-    console.log("[harness] person3 paste (prepend)");
-    await pasteBlock(w3, PERSON3_BLOCK, true);
-    await sleep(BETWEEN_PASTE_MS);
+    console.log('[harness] person3 paste (prepend)')
+    await pasteBlock(w3, PERSON3_BLOCK, true)
+    await sleep(BETWEEN_PASTE_MS)
 
-    console.log("[harness] person1 top line");
-    await insertTopLineAtIndex(w1, TOP_LINE_1, 0, false);
-    await sleep(BETWEEN_PASTE_MS);
+    console.log('[harness] person1 top line')
+    await insertTopLineAtIndex(w1, TOP_LINE_1, 0, false)
+    await sleep(BETWEEN_PASTE_MS)
 
-    console.log("[harness] person2 top line");
-    await insertTopLineAtIndex(w2, TOP_LINE_2, 1, false);
-    await sleep(BETWEEN_PASTE_MS);
+    console.log('[harness] person2 top line')
+    await insertTopLineAtIndex(w2, TOP_LINE_2, 1, false)
+    await sleep(BETWEEN_PASTE_MS)
 
-    console.log("[harness] person3 top line");
-    await insertTopLineAtIndex(w3, TOP_LINE_3, 2, true);
-    await sleep(BETWEEN_PASTE_MS);
+    console.log('[harness] person3 top line')
+    await insertTopLineAtIndex(w3, TOP_LINE_3, 2, true)
+    await sleep(BETWEEN_PASTE_MS)
 
-    console.log("[harness] person1 delete top line");
-    await deleteLineAtIndex(w1, 0);
-    await sleep(BETWEEN_PASTE_MS);
+    console.log('[harness] person1 delete top line')
+    await deleteLineAtIndex(w1, 0)
+    await sleep(BETWEEN_PASTE_MS)
 
-    console.log("[harness] person3 add 6 blank lines after person3 block");
-    await insertBlankLinesAfterPerson3Block(w3, PERSON3_EXTRA_BLANK_COUNT);
-    await sleep(BETWEEN_PASTE_MS);
+    console.log('[harness] person3 add 6 blank lines after person3 block')
+    await insertBlankLinesAfterPerson3Block(w3, PERSON3_EXTRA_BLANK_COUNT)
+    await sleep(BETWEEN_PASTE_MS)
 
-    console.log("[harness] person2 remove 6 blank lines after person3 block");
-    await removeBlankLinesAfterPerson3Block(w2, PERSON3_EXTRA_BLANK_COUNT);
-    await sleep(BETWEEN_PASTE_MS);
+    console.log('[harness] person2 remove 6 blank lines after person3 block')
+    await removeBlankLinesAfterPerson3Block(w2, PERSON3_EXTRA_BLANK_COUNT)
+    await sleep(BETWEEN_PASTE_MS)
 
-    console.log("[harness] person3 add 6 trailing spaces on top line 3");
-    await addTrailingSpacesToTopLine3(w3, TRAILING_SPACES_COUNT);
-    await sleep(BETWEEN_PASTE_MS);
+    console.log('[harness] person3 add 6 trailing spaces on top line 3')
+    await addTrailingSpacesToTopLine3(w3, TRAILING_SPACES_COUNT)
+    await sleep(BETWEEN_PASTE_MS)
 
-    console.log("[harness] person2 remove trailing spaces on top line 3");
-    await removeTrailingSpacesFromTopLine3(w2);
-    await sleep(BETWEEN_PASTE_MS);
+    console.log('[harness] person2 remove trailing spaces on top line 3')
+    await removeTrailingSpacesFromTopLine3(w2)
+    await sleep(BETWEEN_PASTE_MS)
 
-    console.log("[harness] waiting for convergence");
-    const { converged, texts } = await waitForConvergence(windows, EXPECTED_FINAL_TEXT);
+    console.log('[harness] waiting for convergence')
+    const { converged, texts } = await waitForConvergence(windows, EXPECTED_FINAL_TEXT)
 
-    await sleep(2_000);
+    await sleep(2_000)
 
-    const instances = [];
+    const instances = []
     for (let i = 0; i < windows.length; i += 1) {
-      const peer = PEERS[i];
-      const win = windows[i];
-      const rawText = typeof texts[i] === "string" ? texts[i] : await getText(win);
-      const gutter = await getGutterMarks(win);
-      const marks = Array.isArray(gutter?.marks) ? gutter.marks : [];
-      const metrics = gutter?.metrics || null;
-      const names = distinctNames(marks);
-      const tokens = distinctAuthorTokens(marks);
-      const lineOwners = computeLineOwners(rawText, marks, metrics);
+      const peer = PEERS[i]
+      const win = windows[i]
+      const rawText = typeof texts[i] === 'string' ? texts[i] : await getText(win)
+      const gutter = await getGutterMarks(win)
+      const marks = Array.isArray(gutter?.marks) ? gutter.marks : []
+      const metrics = gutter?.metrics || null
+      const names = distinctNames(marks)
+      const tokens = distinctAuthorTokens(marks)
+      const lineOwners = computeLineOwners(rawText, marks, metrics)
 
-      const screenshotPath = await captureScreenshot(win, screenshotDir, `${peer.name}.png`);
+      const screenshotPath = await captureScreenshot(win, screenshotDir, `${peer.name}.png`)
 
       instances.push({
         name: peer.name,
         role: peer.role,
-        text: typeof rawText === "string" ? rawText : "",
-        converged: typeof rawText === "string" && rawText.trim() === EXPECTED_FINAL_TEXT.trim(),
+        text: typeof rawText === 'string' ? rawText : '',
+        converged: typeof rawText === 'string' && rawText.trim() === EXPECTED_FINAL_TEXT.trim(),
         markCount: marks.length,
         marks,
         metrics,
@@ -582,26 +582,26 @@ app.whenReady().then(async () => {
         distinctAuthorTokens: tokens,
         distinctAuthors: tokens.length,
         gutterGaps: computeGaps(marks),
-        screenshotPath,
-      });
+        screenshotPath
+      })
     }
 
-    emitResult({ ok: true, converged, expectedFinalText: EXPECTED_FINAL_TEXT, instances });
-    app.exit(0);
+    emitResult({ ok: true, converged, expectedFinalText: EXPECTED_FINAL_TEXT, instances })
+    app.exit(0)
   } catch (error) {
-    const instances = [];
+    const instances = []
     for (let i = 0; i < windows.length; i += 1) {
-      const peer = PEERS[i];
-      const win = windows[i];
-      const text = await getText(win).catch(() => "");
-      const gutter = await getGutterMarks(win).catch(() => ({ marks: [] }));
-      const marks = Array.isArray(gutter?.marks) ? gutter.marks : [];
-      const metrics = gutter?.metrics || null;
-      const screenshotPath = await captureScreenshot(win, screenshotDir, `${peer.name}-error.png`).catch(() => null);
+      const peer = PEERS[i]
+      const win = windows[i]
+      const text = await getText(win).catch(() => '')
+      const gutter = await getGutterMarks(win).catch(() => ({ marks: [] }))
+      const marks = Array.isArray(gutter?.marks) ? gutter.marks : []
+      const metrics = gutter?.metrics || null
+      const screenshotPath = await captureScreenshot(win, screenshotDir, `${peer.name}-error.png`).catch(() => null)
       instances.push({
         name: peer.name,
         role: peer.role,
-        text: typeof text === "string" ? text : "",
+        text: typeof text === 'string' ? text : '',
         markCount: marks.length,
         marks,
         metrics,
@@ -610,18 +610,18 @@ app.whenReady().then(async () => {
         distinctAuthorTokens: distinctAuthorTokens(marks),
         distinctAuthors: distinctAuthorTokens(marks).length,
         gutterGaps: computeGaps(marks),
-        screenshotPath,
-      });
+        screenshotPath
+      })
     }
 
-    emitResult({ ok: false, error: String(error?.message || error), instances });
-    app.exit(1);
+    emitResult({ ok: false, error: String(error?.message || error), instances })
+    app.exit(1)
   } finally {
     for (const win of windows) {
       try {
-        if (win && !win.isDestroyed()) win.destroy();
+        if (win && !win.isDestroyed()) win.destroy()
       } catch {
       }
     }
   }
-});
+})

--- a/test/integration/p2pmd-gutter-sync-harness.mjs
+++ b/test/integration/p2pmd-gutter-sync-harness.mjs
@@ -43,9 +43,11 @@ const PERSON3_BLOCK = "# person3\n- line1\n- line2\n- line3";
 const TOP_LINE_1 = "first line after block by person1";
 const TOP_LINE_2 = "second line after block by person 2";
 const TOP_LINE_3 = "third line after block by person 3";
+const PERSON3_EXTRA_BLANK_COUNT = 6;
+const TRAILING_SPACES_COUNT = 6;
 
 const EXPECTED_FINAL_TEXT =
-  "first line after block by person1\nsecond line after block by person 2\nthird line after block by person 3\n\n# person3\n- line1\n- line2\n- line3\n\n# person1\n- line1\n- line2\n- line3\n\n# person2\n- line1\n- line2\n- line3";
+  "second line after block by person 2\nthird line after block by person 3\n\n# person3\n- line1\n- line2\n- line3\n\n# person1\n- line1\n- line2\n- line3\n\n# person2\n- line1\n- line2\n- line3";
 
 function emitResult(payload) {
   process.stdout.write(`${RESULT_PREFIX}${JSON.stringify(payload)}\n`);
@@ -244,6 +246,119 @@ async function insertTopLineAtIndex(win, lineText, index, ensureBlankAfterTop = 
   );
 }
 
+async function deleteLineAtIndex(win, index) {
+  return safeExec(
+    win,
+    `
+      (() => {
+        const ta = document.getElementById("markdownInput");
+        if (!ta) return { ok: false, reason: "markdownInput missing" };
+        const current = ta.value || "";
+        const lines = current.length > 0 ? current.split("\\n") : [];
+        const idx = Math.max(0, Math.min(${index}, Math.max(0, lines.length - 1)));
+        if (lines.length === 0) return { ok: true, length: 0 };
+        lines.splice(idx, 1);
+        const next = lines.join("\\n");
+        ta.value = next;
+        ta.dispatchEvent(new Event("input", { bubbles: true }));
+        return { ok: true, length: next.length };
+      })();
+    `,
+    "deleteLineAtIndex"
+  );
+}
+
+async function insertBlankLinesAfterPerson3Block(win, blankCount = PERSON3_EXTRA_BLANK_COUNT) {
+  return safeExec(
+    win,
+    `
+      (() => {
+        const ta = document.getElementById("markdownInput");
+        if (!ta) return { ok: false, reason: "markdownInput missing" };
+        const block = ${JSON.stringify(PERSON3_BLOCK)};
+        const spacer = "\\n".repeat(${blankCount});
+        const current = ta.value || "";
+        const idx = current.indexOf(block);
+        if (idx < 0) return { ok: false, reason: "person3 block not found" };
+        const insertAt = idx + block.length;
+        const next = current.slice(0, insertAt) + spacer + current.slice(insertAt);
+        ta.value = next;
+        ta.dispatchEvent(new Event("input", { bubbles: true }));
+        return { ok: true, length: next.length };
+      })();
+    `,
+    "insertBlankLinesAfterPerson3Block"
+  );
+}
+
+async function removeBlankLinesAfterPerson3Block(win, blankCount = PERSON3_EXTRA_BLANK_COUNT) {
+  return safeExec(
+    win,
+    `
+      (() => {
+        const ta = document.getElementById("markdownInput");
+        if (!ta) return { ok: false, reason: "markdownInput missing" };
+        const block = ${JSON.stringify(PERSON3_BLOCK)};
+        const withSpacer = block + "\\n".repeat(${blankCount});
+        const current = ta.value || "";
+        const idx = current.indexOf(withSpacer);
+        if (idx < 0) return { ok: false, reason: "person3 block + spacer not found" };
+        const next = current.slice(0, idx) + block + current.slice(idx + withSpacer.length);
+        ta.value = next;
+        ta.dispatchEvent(new Event("input", { bubbles: true }));
+        return { ok: true, length: next.length };
+      })();
+    `,
+    "removeBlankLinesAfterPerson3Block"
+  );
+}
+
+async function addTrailingSpacesToTopLine3(win, spacesCount = TRAILING_SPACES_COUNT) {
+  return safeExec(
+    win,
+    `
+      (() => {
+        const ta = document.getElementById("markdownInput");
+        if (!ta) return { ok: false, reason: "markdownInput missing" };
+        const target = ${JSON.stringify(TOP_LINE_3)};
+        const current = ta.value || "";
+        const lines = current.split("\\n");
+        const idx = lines.findIndex((line) => line === target);
+        if (idx < 0) return { ok: false, reason: "top line 3 not found" };
+        lines[idx] = target + " ".repeat(${spacesCount});
+        const next = lines.join("\\n");
+        ta.value = next;
+        ta.dispatchEvent(new Event("input", { bubbles: true }));
+        return { ok: true, length: next.length };
+      })();
+    `,
+    "addTrailingSpacesToTopLine3"
+  );
+}
+
+async function removeTrailingSpacesFromTopLine3(win) {
+  return safeExec(
+    win,
+    `
+      (() => {
+        const ta = document.getElementById("markdownInput");
+        if (!ta) return { ok: false, reason: "markdownInput missing" };
+        const target = ${JSON.stringify(TOP_LINE_3)};
+        const current = ta.value || "";
+        const lines = current.split("\\n");
+        const idx = lines.findIndex((line) => line.startsWith(target));
+        if (idx < 0) return { ok: false, reason: "top line 3 not found" };
+        lines[idx] = target;
+        const next = lines.join("\\n");
+        ta.value = next;
+        ta.dispatchEvent(new Event("input", { bubbles: true }));
+        return { ok: true, length: next.length };
+      })();
+    `,
+    "removeTrailingSpacesFromTopLine3"
+  );
+}
+
 async function getText(win) {
   return safeExec(win, `document.getElementById("markdownInput")?.value || ""`, "getText");
 }
@@ -413,6 +528,26 @@ app.whenReady().then(async () => {
 
     console.log("[harness] person3 top line");
     await insertTopLineAtIndex(w3, TOP_LINE_3, 2, true);
+    await sleep(BETWEEN_PASTE_MS);
+
+    console.log("[harness] person1 delete top line");
+    await deleteLineAtIndex(w1, 0);
+    await sleep(BETWEEN_PASTE_MS);
+
+    console.log("[harness] person3 add 6 blank lines after person3 block");
+    await insertBlankLinesAfterPerson3Block(w3, PERSON3_EXTRA_BLANK_COUNT);
+    await sleep(BETWEEN_PASTE_MS);
+
+    console.log("[harness] person2 remove 6 blank lines after person3 block");
+    await removeBlankLinesAfterPerson3Block(w2, PERSON3_EXTRA_BLANK_COUNT);
+    await sleep(BETWEEN_PASTE_MS);
+
+    console.log("[harness] person3 add 6 trailing spaces on top line 3");
+    await addTrailingSpacesToTopLine3(w3, TRAILING_SPACES_COUNT);
+    await sleep(BETWEEN_PASTE_MS);
+
+    console.log("[harness] person2 remove trailing spaces on top line 3");
+    await removeTrailingSpacesFromTopLine3(w2);
     await sleep(BETWEEN_PASTE_MS);
 
     console.log("[harness] waiting for convergence");

--- a/test/integration/p2pmd-gutter-sync.e2e.test.js
+++ b/test/integration/p2pmd-gutter-sync.e2e.test.js
@@ -1,249 +1,249 @@
-import { expect } from "chai";
-import os from "os";
-import path from "path";
-import fs from "fs/promises";
-import http from "http";
-import { spawn } from "child_process";
-import electronPath from "electron";
+import { expect } from 'chai'
+import os from 'os'
+import path from 'path'
+import fs from 'fs/promises'
+import http from 'http'
+import { spawn } from 'child_process'
+import electronPath from 'electron'
 
-const RESULT_PREFIX = "__PEERSKY_RESULT__";
-const HARNESS_TIMEOUT_MS = 260_000;
-const MAX_GAP_PX = 48;
+const RESULT_PREFIX = '__PEERSKY_RESULT__'
+const HARNESS_TIMEOUT_MS = 260_000
+const MAX_GAP_PX = 48
 const EXPECTED_FINAL_TEXT =
-  "second line after block by person 2\nthird line after block by person 3\n\n# person3\n- line1\n- line2\n- line3\n\n# person1\n- line1\n- line2\n- line3\n\n# person2\n- line1\n- line2\n- line3";
+  'second line after block by person 2\nthird line after block by person 3\n\n# person3\n- line1\n- line2\n- line3\n\n# person1\n- line1\n- line2\n- line3\n\n# person2\n- line1\n- line2\n- line3'
 
-function createRoomServer() {
-  let docContent = "";
-  let yjsStateB64 = null;
-  const peers = new Map();
-  const clients = new Set();
+function createRoomServer () {
+  let docContent = ''
+  let yjsStateB64 = null
+  const peers = new Map()
+  const clients = new Set()
 
-  function broadcast(eventName, data) {
-    const payload = `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`;
+  function broadcast (eventName, data) {
+    const payload = `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`
     for (const res of clients) {
       try {
-        res.write(payload);
+        res.write(payload)
       } catch {
-        clients.delete(res);
+        clients.delete(res)
       }
     }
   }
 
-  function broadcastPeerList() {
-    broadcast("peerlist", Array.from(peers.values()));
+  function broadcastPeerList () {
+    broadcast('peerlist', Array.from(peers.values()))
   }
 
-  function parseBody(req) {
+  function parseBody (req) {
     return new Promise((resolve, reject) => {
-      let body = "";
-      req.on("data", (chunk) => {
-        body += chunk;
-      });
-      req.on("end", () => {
+      let body = ''
+      req.on('data', (chunk) => {
+        body += chunk
+      })
+      req.on('end', () => {
         try {
-          resolve(body ? JSON.parse(body) : {});
+          resolve(body ? JSON.parse(body) : {})
         } catch (error) {
-          reject(error);
+          reject(error)
         }
-      });
-      req.on("error", reject);
-    });
+      })
+      req.on('error', reject)
+    })
   }
 
-  function json(res, statusCode, obj) {
-    const body = JSON.stringify(obj);
+  function json (res, statusCode, obj) {
+    const body = JSON.stringify(obj)
     res.writeHead(statusCode, {
-      "Content-Type": "application/json",
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Headers": "Content-Type",
-    });
-    res.end(body);
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    })
+    res.end(body)
   }
 
   const server = http.createServer(async (req, res) => {
-    if (req.method === "OPTIONS") {
+    if (req.method === 'OPTIONS') {
       res.writeHead(204, {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type",
-      });
-      res.end();
-      return;
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type'
+      })
+      res.end()
+      return
     }
 
-    const url = new URL(req.url, "http://localhost");
-    const pathname = url.pathname;
+    const url = new URL(req.url, 'http://localhost')
+    const pathname = url.pathname
 
-    if (pathname === "/events" && req.method === "GET") {
+    if (pathname === '/events' && req.method === 'GET') {
       res.writeHead(200, {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-        "Access-Control-Allow-Origin": "*",
-      });
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'Access-Control-Allow-Origin': '*'
+      })
 
-      const clientId = url.searchParams.get("clientId") || `anon-${Date.now()}`;
-      const role = url.searchParams.get("role") || "client";
-      const color = url.searchParams.get("color") || "#888888";
-      const name = url.searchParams.get("name") || clientId.slice(0, 8);
+      const clientId = url.searchParams.get('clientId') || `anon-${Date.now()}`
+      const role = url.searchParams.get('role') || 'client'
+      const color = url.searchParams.get('color') || '#888888'
+      const name = url.searchParams.get('name') || clientId.slice(0, 8)
 
       if (!peers.has(clientId)) {
-        peers.set(clientId, { clientId, role, color, name, cursorLine: 1, cursorColumn: 1 });
-        broadcastPeerList();
+        peers.set(clientId, { clientId, role, color, name, cursorLine: 1, cursorColumn: 1 })
+        broadcastPeerList()
       }
 
-      clients.add(res);
-      res.write(`event: update\ndata: ${JSON.stringify({ content: docContent })}\n\n`);
-      res.write(`event: peerlist\ndata: ${JSON.stringify(Array.from(peers.values()))}\n\n`);
+      clients.add(res)
+      res.write(`event: update\ndata: ${JSON.stringify({ content: docContent })}\n\n`)
+      res.write(`event: peerlist\ndata: ${JSON.stringify(Array.from(peers.values()))}\n\n`)
       if (yjsStateB64) {
-        res.write(`event: yjsupdate\ndata: ${yjsStateB64}\n\n`);
+        res.write(`event: yjsupdate\ndata: ${yjsStateB64}\n\n`)
       }
 
-      req.on("close", () => {
-        clients.delete(res);
-        peers.delete(clientId);
-        broadcastPeerList();
-      });
-      return;
+      req.on('close', () => {
+        clients.delete(res)
+        peers.delete(clientId)
+        broadcastPeerList()
+      })
+      return
     }
 
-    if (pathname === "/status" && req.method === "GET") {
-      return json(res, 200, { peers: peers.size, peerList: Array.from(peers.values()) });
+    if (pathname === '/status' && req.method === 'GET') {
+      return json(res, 200, { peers: peers.size, peerList: Array.from(peers.values()) })
     }
 
-    if (pathname === "/doc" && req.method === "GET") {
-      return json(res, 200, { content: docContent });
+    if (pathname === '/doc' && req.method === 'GET') {
+      return json(res, 200, { content: docContent })
     }
 
-    if (pathname === "/doc" && req.method === "POST") {
+    if (pathname === '/doc' && req.method === 'POST') {
       try {
-        const body = await parseBody(req);
-        if (typeof body.content === "string") {
-          docContent = body.content;
+        const body = await parseBody(req)
+        if (typeof body.content === 'string') {
+          docContent = body.content
           if (body.clientId && peers.has(body.clientId) && body.lineAttributions) {
-            const peer = peers.get(body.clientId);
-            peer.lineAttributions = body.lineAttributions;
-            if (body.name) peer.name = body.name;
-            if (body.color) peer.color = body.color;
+            const peer = peers.get(body.clientId)
+            peer.lineAttributions = body.lineAttributions
+            if (body.name) peer.name = body.name
+            if (body.color) peer.color = body.color
           }
-          broadcast("update", { content: docContent, latexModeEnabled: false });
-          broadcastPeerList();
+          broadcast('update', { content: docContent, latexModeEnabled: false })
+          broadcastPeerList()
         }
-        return json(res, 200, { ok: true });
+        return json(res, 200, { ok: true })
       } catch (error) {
-        return json(res, 400, { error: String(error.message) });
+        return json(res, 400, { error: String(error.message) })
       }
     }
 
-    if (pathname === "/doc/update" && req.method === "POST") {
+    if (pathname === '/doc/update' && req.method === 'POST') {
       try {
-        const body = await parseBody(req);
-        if (typeof body.update === "string") {
-          yjsStateB64 = body.update;
-          if (typeof body.content === "string") docContent = body.content;
+        const body = await parseBody(req)
+        if (typeof body.update === 'string') {
+          yjsStateB64 = body.update
+          if (typeof body.content === 'string') docContent = body.content
           if (body.clientId && body.lineAttributions) {
-            const peer = peers.get(body.clientId) || { clientId: body.clientId };
-            peer.lineAttributions = body.lineAttributions;
-            if (body.name) peer.name = body.name;
-            if (body.color) peer.color = body.color;
-            peers.set(body.clientId, peer);
+            const peer = peers.get(body.clientId) || { clientId: body.clientId }
+            peer.lineAttributions = body.lineAttributions
+            if (body.name) peer.name = body.name
+            if (body.color) peer.color = body.color
+            peers.set(body.clientId, peer)
           }
-          broadcast("yjsupdate", body.update);
-          broadcastPeerList();
+          broadcast('yjsupdate', body.update)
+          broadcastPeerList()
         }
-        return json(res, 200, { ok: true });
+        return json(res, 200, { ok: true })
       } catch (error) {
-        return json(res, 400, { error: String(error.message) });
+        return json(res, 400, { error: String(error.message) })
       }
     }
 
-    if (pathname === "/doc/yjsstate" && req.method === "GET") {
-      return json(res, 200, { yjsState: yjsStateB64 });
+    if (pathname === '/doc/yjsstate' && req.method === 'GET') {
+      return json(res, 200, { yjsState: yjsStateB64 })
     }
 
-    if (pathname === "/presence" && req.method === "POST") {
+    if (pathname === '/presence' && req.method === 'POST') {
       try {
-        const body = await parseBody(req);
+        const body = await parseBody(req)
         if (body.clientId) {
-          const existing = peers.get(body.clientId) || {};
-          peers.set(body.clientId, { ...existing, ...body });
-          broadcastPeerList();
+          const existing = peers.get(body.clientId) || {}
+          peers.set(body.clientId, { ...existing, ...body })
+          broadcastPeerList()
         }
-        return json(res, 200, { ok: true });
+        return json(res, 200, { ok: true })
       } catch (error) {
-        return json(res, 400, { error: String(error.message) });
+        return json(res, 400, { error: String(error.message) })
       }
     }
 
-    res.writeHead(404, { "Access-Control-Allow-Origin": "*" });
-    res.end("Not found");
-  });
+    res.writeHead(404, { 'Access-Control-Allow-Origin': '*' })
+    res.end('Not found')
+  })
 
   return new Promise((resolve, reject) => {
-    server.listen(0, "127.0.0.1", () => {
-      const { port } = server.address();
-      resolve({ server, localUrl: `http://127.0.0.1:${port}` });
-    });
-    server.on("error", reject);
-  });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address()
+      resolve({ server, localUrl: `http://127.0.0.1:${port}` })
+    })
+    server.on('error', reject)
+  })
 }
 
-function runHarness({ userDataDir, localUrl, timeoutMs = HARNESS_TIMEOUT_MS }) {
+function runHarness ({ userDataDir, localUrl, timeoutMs = HARNESS_TIMEOUT_MS }) {
   return new Promise((resolve, reject) => {
-    const harnessPath = path.resolve("test/integration/p2pmd-gutter-sync-harness.mjs");
-    const args = [harnessPath, "--user-data", userDataDir, "--room-url", localUrl];
+    const harnessPath = path.resolve('test/integration/p2pmd-gutter-sync-harness.mjs')
+    const args = [harnessPath, '--user-data', userDataDir, '--room-url', localUrl]
     const env = {
       ...process.env,
-      ELECTRON_DISABLE_SECURITY_WARNINGS: "true",
-    };
-    delete env.ELECTRON_RUN_AS_NODE;
+      ELECTRON_DISABLE_SECURITY_WARNINGS: 'true'
+    }
+    delete env.ELECTRON_RUN_AS_NODE
 
     const child = spawn(electronPath, args, {
-      cwd: path.resolve("."),
+      cwd: path.resolve('.'),
       env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
 
-    let stdout = "";
-    let stderr = "";
-    let parsed = null;
-    let lineBuffer = "";
+    let stdout = ''
+    let stderr = ''
+    let parsed = null
+    let lineBuffer = ''
 
     const timer = setTimeout(() => {
-      child.kill();
-      reject(new Error(`Harness timeout after ${timeoutMs}ms`));
-    }, timeoutMs);
+      child.kill()
+      reject(new Error(`Harness timeout after ${timeoutMs}ms`))
+    }, timeoutMs)
 
-    child.stdout.on("data", (chunk) => {
-      const text = String(chunk);
-      stdout += text;
-      lineBuffer += text;
-      const lines = lineBuffer.split(/\r?\n/);
-      lineBuffer = lines.pop() || "";
+    child.stdout.on('data', (chunk) => {
+      const text = String(chunk)
+      stdout += text
+      lineBuffer += text
+      const lines = lineBuffer.split(/\r?\n/)
+      lineBuffer = lines.pop() || ''
       for (const line of lines) {
         if (line.startsWith(RESULT_PREFIX)) {
           try {
-            parsed = JSON.parse(line.slice(RESULT_PREFIX.length));
+            parsed = JSON.parse(line.slice(RESULT_PREFIX.length))
           } catch {
           }
         }
       }
-    });
+    })
 
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
 
-    child.on("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
 
-    child.on("close", (code) => {
-      clearTimeout(timer);
+    child.on('close', (code) => {
+      clearTimeout(timer)
       if (!parsed && lineBuffer.startsWith(RESULT_PREFIX)) {
         try {
-          parsed = JSON.parse(lineBuffer.slice(RESULT_PREFIX.length));
+          parsed = JSON.parse(lineBuffer.slice(RESULT_PREFIX.length))
         } catch {
         }
       }
@@ -254,111 +254,111 @@ function runHarness({ userDataDir, localUrl, timeoutMs = HARNESS_TIMEOUT_MS }) {
               `--- stdout tail ---\n${stdout.slice(-4000)}\n` +
               `--- stderr tail ---\n${stderr.slice(-4000)}`
           )
-        );
-        return;
+        )
+        return
       }
-      resolve({ code, result: parsed, stdout, stderr });
-    });
-  });
+      resolve({ code, result: parsed, stdout, stderr })
+    })
+  })
 }
 
-function formatDiagnostics(result, stdout, stderr) {
-  let out = "";
+function formatDiagnostics (result, stdout, stderr) {
+  let out = ''
   if (result?.error) {
-    out += `Harness error: ${result.error}\n`;
+    out += `Harness error: ${result.error}\n`
   }
   for (const inst of result?.instances || []) {
-    out += `\n[${inst.name}/${inst.role}] converged=${inst.converged} markCount=${inst.markCount} distinctAuthors=${inst.distinctAuthors}\n`;
-    out += `  names=${JSON.stringify(inst.distinctAuthorNames || [])}\n`;
-    out += `  authorTokens=${JSON.stringify(inst.distinctAuthorTokens || [])}\n`;
-    out += `  gaps=${JSON.stringify(inst.gutterGaps || [])}\n`;
-    out += `  lineOwners=${JSON.stringify((inst.lineOwners || []).map((l) => ({ line: l.line, text: l.text, name: l.name, token: l.token })))}\n`;
-    out += `  textHead=${JSON.stringify((inst.text || "").slice(0, 220))}\n`;
-    out += `  screenshot=${inst.screenshotPath || "(none)"}\n`;
+    out += `\n[${inst.name}/${inst.role}] converged=${inst.converged} markCount=${inst.markCount} distinctAuthors=${inst.distinctAuthors}\n`
+    out += `  names=${JSON.stringify(inst.distinctAuthorNames || [])}\n`
+    out += `  authorTokens=${JSON.stringify(inst.distinctAuthorTokens || [])}\n`
+    out += `  gaps=${JSON.stringify(inst.gutterGaps || [])}\n`
+    out += `  lineOwners=${JSON.stringify((inst.lineOwners || []).map((l) => ({ line: l.line, text: l.text, name: l.name, token: l.token })))}\n`
+    out += `  textHead=${JSON.stringify((inst.text || '').slice(0, 220))}\n`
+    out += `  screenshot=${inst.screenshotPath || '(none)'}\n`
   }
-  if (stderr) out += `\n--- harness stderr ---\n${stderr.slice(-2000)}\n`;
-  if (stdout) out += `\n--- harness stdout tail ---\n${stdout.slice(-2000)}\n`;
-  return out;
+  if (stderr) out += `\n--- harness stderr ---\n${stderr.slice(-2000)}\n`
+  if (stdout) out += `\n--- harness stdout tail ---\n${stdout.slice(-2000)}\n`
+  return out
 }
 
-describe("p2pmd: 3-peer gutter sync E2E (distributed edits)", function () {
-  this.timeout(HARNESS_TIMEOUT_MS + 20_000);
+describe('p2pmd: 3-peer gutter sync E2E (distributed edits)', function () {
+  this.timeout(HARNESS_TIMEOUT_MS + 20_000)
 
-  let roomServerHandle = null;
-  let userDataDir = null;
+  let roomServerHandle = null
+  let userDataDir = null
 
   before(async function () {
-    roomServerHandle = await createRoomServer();
-    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "peersky-p2pmd-gutter-e2e-"));
-    userDataDir = path.join(tmpRoot, "user-data");
-    await fs.mkdir(userDataDir, { recursive: true });
-  });
+    roomServerHandle = await createRoomServer()
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'peersky-p2pmd-gutter-e2e-'))
+    userDataDir = path.join(tmpRoot, 'user-data')
+    await fs.mkdir(userDataDir, { recursive: true })
+  })
 
   after(async function () {
     if (roomServerHandle?.server) {
-      await new Promise((resolve) => roomServerHandle.server.close(resolve));
+      await new Promise((resolve) => roomServerHandle.server.close(resolve))
     }
-  });
+  })
 
-  it("keeps text and gutter attribution synced across all 3 peers", async function () {
+  it('keeps text and gutter attribution synced across all 3 peers', async function () {
     const { result, stdout, stderr } = await runHarness({
       userDataDir,
-      localUrl: roomServerHandle.localUrl,
-    });
+      localUrl: roomServerHandle.localUrl
+    })
 
     if (!result.ok) {
-      throw new Error(formatDiagnostics(result, stdout, stderr));
+      throw new Error(formatDiagnostics(result, stdout, stderr))
     }
 
-    expect(result.instances, "Expected 3 instance snapshots").to.have.length(3);
+    expect(result.instances, 'Expected 3 instance snapshots').to.have.length(3)
 
-    const failures = [];
-    const nonEmptyLineOwnerByInstance = {};
+    const failures = []
+    const nonEmptyLineOwnerByInstance = {}
     for (const inst of result.instances) {
-      if ((inst.text || "").trim() !== EXPECTED_FINAL_TEXT.trim()) failures.push(`${inst.name}: text mismatch`);
-      if (inst.converged !== true) failures.push(`${inst.name}: convergence flag false`);
-      if (!(inst.markCount > 0)) failures.push(`${inst.name}: no gutter marks`);
-      if (!(inst.markCount >= 3)) failures.push(`${inst.name}: too few gutter marks (${inst.markCount})`);
-      if (!(inst.distinctAuthors >= 3)) failures.push(`${inst.name}: expected >=3 author groups, got ${inst.distinctAuthors}`);
+      if ((inst.text || '').trim() !== EXPECTED_FINAL_TEXT.trim()) failures.push(`${inst.name}: text mismatch`)
+      if (inst.converged !== true) failures.push(`${inst.name}: convergence flag false`)
+      if (!(inst.markCount > 0)) failures.push(`${inst.name}: no gutter marks`)
+      if (!(inst.markCount >= 3)) failures.push(`${inst.name}: too few gutter marks (${inst.markCount})`)
+      if (!(inst.distinctAuthors >= 3)) failures.push(`${inst.name}: expected >=3 author groups, got ${inst.distinctAuthors}`)
 
-      const marks = Array.isArray(inst.marks) ? inst.marks : [];
-      const sorted = [...marks].sort((a, b) => (a.top || 0) - (b.top || 0));
-      const firstTop = sorted.length ? Number(sorted[0].top || 0) : Infinity;
-      const lastTop = sorted.length ? Number(sorted[sorted.length - 1].top || 0) : -Infinity;
-      if (!(firstTop < 170)) failures.push(`${inst.name}: first gutter mark starts too low (${firstTop})`);
-      if (!((lastTop - firstTop) > 120)) failures.push(`${inst.name}: gutter marks do not span content (${lastTop - firstTop})`);
+      const marks = Array.isArray(inst.marks) ? inst.marks : []
+      const sorted = [...marks].sort((a, b) => (a.top || 0) - (b.top || 0))
+      const firstTop = sorted.length ? Number(sorted[0].top || 0) : Infinity
+      const lastTop = sorted.length ? Number(sorted[sorted.length - 1].top || 0) : -Infinity
+      if (!(firstTop < 170)) failures.push(`${inst.name}: first gutter mark starts too low (${firstTop})`)
+      if (!((lastTop - firstTop) > 120)) failures.push(`${inst.name}: gutter marks do not span content (${lastTop - firstTop})`)
 
       for (const gap of inst.gutterGaps || []) {
-        if (!(gap <= MAX_GAP_PX)) failures.push(`${inst.name}: large blank gutter gap ${gap}px`);
+        if (!(gap <= MAX_GAP_PX)) failures.push(`${inst.name}: large blank gutter gap ${gap}px`)
       }
 
       const nonEmpty = (inst.lineOwners || [])
-        .filter((line) => String(line.text || "").trim().length > 0)
-        .map((line) => ({ line: line.line, text: line.text, name: line.name || null, token: line.token || null }));
-      nonEmptyLineOwnerByInstance[inst.name] = nonEmpty;
+        .filter((line) => String(line.text || '').trim().length > 0)
+        .map((line) => ({ line: line.line, text: line.text, name: line.name || null, token: line.token || null }))
+      nonEmptyLineOwnerByInstance[inst.name] = nonEmpty
       for (const line of nonEmpty) {
-        if (!line.name) failures.push(`${inst.name}: missing owner at line ${line.line} (${line.text})`);
+        if (!line.name) failures.push(`${inst.name}: missing owner at line ${line.line} (${line.text})`)
       }
     }
 
     // Cross-peer strict sync: each non-empty line should resolve to the same owner token on all peers.
-    const [baseName, ...otherNames] = Object.keys(nonEmptyLineOwnerByInstance);
-    const baseOwners = nonEmptyLineOwnerByInstance[baseName] || [];
+    const [baseName, ...otherNames] = Object.keys(nonEmptyLineOwnerByInstance)
+    const baseOwners = nonEmptyLineOwnerByInstance[baseName] || []
     for (const peerName of otherNames) {
-      const peerOwners = nonEmptyLineOwnerByInstance[peerName] || [];
+      const peerOwners = nonEmptyLineOwnerByInstance[peerName] || []
       if (peerOwners.length !== baseOwners.length) {
-        failures.push(`${peerName}: non-empty line owner length mismatch (${peerOwners.length} vs ${baseOwners.length})`);
-        continue;
+        failures.push(`${peerName}: non-empty line owner length mismatch (${peerOwners.length} vs ${baseOwners.length})`)
+        continue
       }
       for (let i = 0; i < baseOwners.length; i += 1) {
-        const a = baseOwners[i];
-        const b = peerOwners[i];
+        const a = baseOwners[i]
+        const b = peerOwners[i]
         if (a.line !== b.line || a.text !== b.text) {
-          failures.push(`${peerName}: line structure mismatch at index ${i}`);
-          continue;
+          failures.push(`${peerName}: line structure mismatch at index ${i}`)
+          continue
         }
         if ((a.token || null) !== (b.token || null)) {
-          failures.push(`${peerName}: owner token mismatch at line ${a.line} (${a.text})`);
+          failures.push(`${peerName}: owner token mismatch at line ${a.line} (${a.text})`)
         }
       }
     }
@@ -367,25 +367,25 @@ describe("p2pmd: 3-peer gutter sync E2E (distributed edits)", function () {
     // line ownership should remain stable for each person block.
     // Top lines can legitimately change owner if another peer edits them.
     const expectedOwnerByLine = new Map([
-      [1, "person2"],
-      [2, "person2"],
-      [4, "person3"], [5, "person3"], [6, "person3"], [7, "person3"],
-      [9, "person1"], [10, "person1"], [11, "person1"], [12, "person1"],
-      [14, "person2"], [15, "person2"], [16, "person2"], [17, "person2"],
-    ]);
+      [1, 'person2'],
+      [2, 'person2'],
+      [4, 'person3'], [5, 'person3'], [6, 'person3'], [7, 'person3'],
+      [9, 'person1'], [10, 'person1'], [11, 'person1'], [12, 'person1'],
+      [14, 'person2'], [15, 'person2'], [16, 'person2'], [17, 'person2']
+    ])
     for (const inst of result.instances) {
-      const byLine = new Map((inst.lineOwners || []).map((line) => [line.line, line]));
+      const byLine = new Map((inst.lineOwners || []).map((line) => [line.line, line]))
       for (const [lineNo, expectedOwner] of expectedOwnerByLine.entries()) {
-        const found = byLine.get(lineNo);
-        const foundName = String(found?.name || "").trim().toLowerCase();
+        const found = byLine.get(lineNo)
+        const foundName = String(found?.name || '').trim().toLowerCase()
         if (foundName !== expectedOwner) {
-          failures.push(`${inst.name}: line ${lineNo} expected owner ${expectedOwner}, got ${foundName || "(none)"}`);
+          failures.push(`${inst.name}: line ${lineNo} expected owner ${expectedOwner}, got ${foundName || '(none)'}`)
         }
       }
     }
 
     if (failures.length > 0) {
-      throw new Error(`${failures.join("\n")}\n\n${formatDiagnostics(result, stdout, stderr)}`);
+      throw new Error(`${failures.join('\n')}\n\n${formatDiagnostics(result, stdout, stderr)}`)
     }
-  });
-});
+  })
+})

--- a/test/integration/p2pmd-gutter-sync.e2e.test.js
+++ b/test/integration/p2pmd-gutter-sync.e2e.test.js
@@ -1,0 +1,394 @@
+import { expect } from "chai";
+import os from "os";
+import path from "path";
+import fs from "fs/promises";
+import http from "http";
+import { spawn } from "child_process";
+import electronPath from "electron";
+
+const RESULT_PREFIX = "__PEERSKY_RESULT__";
+const HARNESS_TIMEOUT_MS = 260_000;
+const MAX_GAP_PX = 48;
+const EXPECTED_FINAL_TEXT =
+  "first line after block by person1\nsecond line after block by person 2\nthird line after block by person 3\n\n# person3\n- line1\n- line2\n- line3\n\n# person1\n- line1\n- line2\n- line3\n\n# person2\n- line1\n- line2\n- line3";
+
+function createRoomServer() {
+  let docContent = "";
+  let yjsStateB64 = null;
+  const peers = new Map();
+  const clients = new Set();
+
+  function broadcast(eventName, data) {
+    const payload = `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`;
+    for (const res of clients) {
+      try {
+        res.write(payload);
+      } catch {
+        clients.delete(res);
+      }
+    }
+  }
+
+  function broadcastPeerList() {
+    broadcast("peerlist", Array.from(peers.values()));
+  }
+
+  function parseBody(req) {
+    return new Promise((resolve, reject) => {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        try {
+          resolve(body ? JSON.parse(body) : {});
+        } catch (error) {
+          reject(error);
+        }
+      });
+      req.on("error", reject);
+    });
+  }
+
+  function json(res, statusCode, obj) {
+    const body = JSON.stringify(obj);
+    res.writeHead(statusCode, {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Headers": "Content-Type",
+    });
+    res.end(body);
+  }
+
+  const server = http.createServer(async (req, res) => {
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
+      });
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url, "http://localhost");
+    const pathname = url.pathname;
+
+    if (pathname === "/events" && req.method === "GET") {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+        "Access-Control-Allow-Origin": "*",
+      });
+
+      const clientId = url.searchParams.get("clientId") || `anon-${Date.now()}`;
+      const role = url.searchParams.get("role") || "client";
+      const color = url.searchParams.get("color") || "#888888";
+      const name = url.searchParams.get("name") || clientId.slice(0, 8);
+
+      if (!peers.has(clientId)) {
+        peers.set(clientId, { clientId, role, color, name, cursorLine: 1, cursorColumn: 1 });
+        broadcastPeerList();
+      }
+
+      clients.add(res);
+      res.write(`event: update\ndata: ${JSON.stringify({ content: docContent })}\n\n`);
+      res.write(`event: peerlist\ndata: ${JSON.stringify(Array.from(peers.values()))}\n\n`);
+      if (yjsStateB64) {
+        res.write(`event: yjsupdate\ndata: ${yjsStateB64}\n\n`);
+      }
+
+      req.on("close", () => {
+        clients.delete(res);
+        peers.delete(clientId);
+        broadcastPeerList();
+      });
+      return;
+    }
+
+    if (pathname === "/status" && req.method === "GET") {
+      return json(res, 200, { peers: peers.size, peerList: Array.from(peers.values()) });
+    }
+
+    if (pathname === "/doc" && req.method === "GET") {
+      return json(res, 200, { content: docContent });
+    }
+
+    if (pathname === "/doc" && req.method === "POST") {
+      try {
+        const body = await parseBody(req);
+        if (typeof body.content === "string") {
+          docContent = body.content;
+          if (body.clientId && peers.has(body.clientId) && body.lineAttributions) {
+            const peer = peers.get(body.clientId);
+            peer.lineAttributions = body.lineAttributions;
+            if (body.name) peer.name = body.name;
+            if (body.color) peer.color = body.color;
+          }
+          broadcast("update", { content: docContent, latexModeEnabled: false });
+          broadcastPeerList();
+        }
+        return json(res, 200, { ok: true });
+      } catch (error) {
+        return json(res, 400, { error: String(error.message) });
+      }
+    }
+
+    if (pathname === "/doc/update" && req.method === "POST") {
+      try {
+        const body = await parseBody(req);
+        if (typeof body.update === "string") {
+          yjsStateB64 = body.update;
+          if (typeof body.content === "string") docContent = body.content;
+          if (body.clientId && body.lineAttributions) {
+            const peer = peers.get(body.clientId) || { clientId: body.clientId };
+            peer.lineAttributions = body.lineAttributions;
+            if (body.name) peer.name = body.name;
+            if (body.color) peer.color = body.color;
+            peers.set(body.clientId, peer);
+          }
+          broadcast("yjsupdate", body.update);
+          broadcastPeerList();
+        }
+        return json(res, 200, { ok: true });
+      } catch (error) {
+        return json(res, 400, { error: String(error.message) });
+      }
+    }
+
+    if (pathname === "/doc/yjsstate" && req.method === "GET") {
+      return json(res, 200, { yjsState: yjsStateB64 });
+    }
+
+    if (pathname === "/presence" && req.method === "POST") {
+      try {
+        const body = await parseBody(req);
+        if (body.clientId) {
+          const existing = peers.get(body.clientId) || {};
+          peers.set(body.clientId, { ...existing, ...body });
+          broadcastPeerList();
+        }
+        return json(res, 200, { ok: true });
+      } catch (error) {
+        return json(res, 400, { error: String(error.message) });
+      }
+    }
+
+    res.writeHead(404, { "Access-Control-Allow-Origin": "*" });
+    res.end("Not found");
+  });
+
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ server, localUrl: `http://127.0.0.1:${port}` });
+    });
+    server.on("error", reject);
+  });
+}
+
+function runHarness({ userDataDir, localUrl, timeoutMs = HARNESS_TIMEOUT_MS }) {
+  return new Promise((resolve, reject) => {
+    const harnessPath = path.resolve("test/integration/p2pmd-gutter-sync-harness.mjs");
+    const args = [harnessPath, "--user-data", userDataDir, "--room-url", localUrl];
+    const env = {
+      ...process.env,
+      ELECTRON_DISABLE_SECURITY_WARNINGS: "true",
+    };
+    delete env.ELECTRON_RUN_AS_NODE;
+
+    const child = spawn(electronPath, args, {
+      cwd: path.resolve("."),
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let parsed = null;
+    let lineBuffer = "";
+
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`Harness timeout after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk) => {
+      const text = String(chunk);
+      stdout += text;
+      lineBuffer += text;
+      const lines = lineBuffer.split(/\r?\n/);
+      lineBuffer = lines.pop() || "";
+      for (const line of lines) {
+        if (line.startsWith(RESULT_PREFIX)) {
+          try {
+            parsed = JSON.parse(line.slice(RESULT_PREFIX.length));
+          } catch {
+          }
+        }
+      }
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (!parsed && lineBuffer.startsWith(RESULT_PREFIX)) {
+        try {
+          parsed = JSON.parse(lineBuffer.slice(RESULT_PREFIX.length));
+        } catch {
+        }
+      }
+      if (!parsed) {
+        reject(
+          new Error(
+            `No harness result payload. code=${code}\n` +
+              `--- stdout tail ---\n${stdout.slice(-4000)}\n` +
+              `--- stderr tail ---\n${stderr.slice(-4000)}`
+          )
+        );
+        return;
+      }
+      resolve({ code, result: parsed, stdout, stderr });
+    });
+  });
+}
+
+function formatDiagnostics(result, stdout, stderr) {
+  let out = "";
+  if (result?.error) {
+    out += `Harness error: ${result.error}\n`;
+  }
+  for (const inst of result?.instances || []) {
+    out += `\n[${inst.name}/${inst.role}] converged=${inst.converged} markCount=${inst.markCount} distinctAuthors=${inst.distinctAuthors}\n`;
+    out += `  names=${JSON.stringify(inst.distinctAuthorNames || [])}\n`;
+    out += `  authorTokens=${JSON.stringify(inst.distinctAuthorTokens || [])}\n`;
+    out += `  gaps=${JSON.stringify(inst.gutterGaps || [])}\n`;
+    out += `  lineOwners=${JSON.stringify((inst.lineOwners || []).map((l) => ({ line: l.line, text: l.text, name: l.name, token: l.token })))}\n`;
+    out += `  textHead=${JSON.stringify((inst.text || "").slice(0, 220))}\n`;
+    out += `  screenshot=${inst.screenshotPath || "(none)"}\n`;
+  }
+  if (stderr) out += `\n--- harness stderr ---\n${stderr.slice(-2000)}\n`;
+  if (stdout) out += `\n--- harness stdout tail ---\n${stdout.slice(-2000)}\n`;
+  return out;
+}
+
+describe("p2pmd: 3-peer gutter sync E2E (distributed edits)", function () {
+  this.timeout(HARNESS_TIMEOUT_MS + 20_000);
+
+  let roomServerHandle = null;
+  let userDataDir = null;
+
+  before(async function () {
+    roomServerHandle = await createRoomServer();
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "peersky-p2pmd-gutter-e2e-"));
+    userDataDir = path.join(tmpRoot, "user-data");
+    await fs.mkdir(userDataDir, { recursive: true });
+  });
+
+  after(async function () {
+    if (roomServerHandle?.server) {
+      await new Promise((resolve) => roomServerHandle.server.close(resolve));
+    }
+  });
+
+  it("keeps text and gutter attribution synced across all 3 peers", async function () {
+    const { result, stdout, stderr } = await runHarness({
+      userDataDir,
+      localUrl: roomServerHandle.localUrl,
+    });
+
+    if (!result.ok) {
+      throw new Error(formatDiagnostics(result, stdout, stderr));
+    }
+
+    expect(result.instances, "Expected 3 instance snapshots").to.have.length(3);
+
+    const failures = [];
+    const nonEmptyLineOwnerByInstance = {};
+    for (const inst of result.instances) {
+      if ((inst.text || "").trim() !== EXPECTED_FINAL_TEXT.trim()) failures.push(`${inst.name}: text mismatch`);
+      if (inst.converged !== true) failures.push(`${inst.name}: convergence flag false`);
+      if (!(inst.markCount > 0)) failures.push(`${inst.name}: no gutter marks`);
+      if (!(inst.markCount >= 3)) failures.push(`${inst.name}: too few gutter marks (${inst.markCount})`);
+      if (!(inst.distinctAuthors >= 3)) failures.push(`${inst.name}: expected >=3 author groups, got ${inst.distinctAuthors}`);
+
+      const marks = Array.isArray(inst.marks) ? inst.marks : [];
+      const sorted = [...marks].sort((a, b) => (a.top || 0) - (b.top || 0));
+      const firstTop = sorted.length ? Number(sorted[0].top || 0) : Infinity;
+      const lastTop = sorted.length ? Number(sorted[sorted.length - 1].top || 0) : -Infinity;
+      if (!(firstTop < 170)) failures.push(`${inst.name}: first gutter mark starts too low (${firstTop})`);
+      if (!((lastTop - firstTop) > 120)) failures.push(`${inst.name}: gutter marks do not span content (${lastTop - firstTop})`);
+
+      for (const gap of inst.gutterGaps || []) {
+        if (!(gap <= MAX_GAP_PX)) failures.push(`${inst.name}: large blank gutter gap ${gap}px`);
+      }
+
+      const nonEmpty = (inst.lineOwners || [])
+        .filter((line) => String(line.text || "").trim().length > 0)
+        .map((line) => ({ line: line.line, text: line.text, name: line.name || null, token: line.token || null }));
+      nonEmptyLineOwnerByInstance[inst.name] = nonEmpty;
+      for (const line of nonEmpty) {
+        if (!line.name) failures.push(`${inst.name}: missing owner at line ${line.line} (${line.text})`);
+      }
+    }
+
+    // Cross-peer strict sync: each non-empty line should resolve to the same owner token on all peers.
+    const [baseName, ...otherNames] = Object.keys(nonEmptyLineOwnerByInstance);
+    const baseOwners = nonEmptyLineOwnerByInstance[baseName] || [];
+    for (const peerName of otherNames) {
+      const peerOwners = nonEmptyLineOwnerByInstance[peerName] || [];
+      if (peerOwners.length !== baseOwners.length) {
+        failures.push(`${peerName}: non-empty line owner length mismatch (${peerOwners.length} vs ${baseOwners.length})`);
+        continue;
+      }
+      for (let i = 0; i < baseOwners.length; i += 1) {
+        const a = baseOwners[i];
+        const b = peerOwners[i];
+        if (a.line !== b.line || a.text !== b.text) {
+          failures.push(`${peerName}: line structure mismatch at index ${i}`);
+          continue;
+        }
+        if ((a.token || null) !== (b.token || null)) {
+          failures.push(`${peerName}: owner token mismatch at line ${a.line} (${a.text})`);
+        }
+      }
+    }
+
+    // Semantic correctness:
+    // top lines authored by respective peers, plus each person block owner.
+    // Final text lines:
+    // 1 => person1, 2 => person2, 3 => person3
+    // 5-8 => person3, 10-13 => person1, 15-18 => person2
+    const expectedOwnerByLine = new Map([
+      [1, "person1"],
+      [2, "person2"],
+      [3, "person3"],
+      [5, "person3"], [6, "person3"], [7, "person3"], [8, "person3"],
+      [10, "person1"], [11, "person1"], [12, "person1"], [13, "person1"],
+      [15, "person2"], [16, "person2"], [17, "person2"], [18, "person2"],
+    ]);
+    for (const inst of result.instances) {
+      const byLine = new Map((inst.lineOwners || []).map((line) => [line.line, line]));
+      for (const [lineNo, expectedOwner] of expectedOwnerByLine.entries()) {
+        const found = byLine.get(lineNo);
+        const foundName = String(found?.name || "").trim().toLowerCase();
+        if (foundName !== expectedOwner) {
+          failures.push(`${inst.name}: line ${lineNo} expected owner ${expectedOwner}, got ${foundName || "(none)"}`);
+        }
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(`${failures.join("\n")}\n\n${formatDiagnostics(result, stdout, stderr)}`);
+    }
+  });
+});

--- a/test/integration/p2pmd-gutter-sync.e2e.test.js
+++ b/test/integration/p2pmd-gutter-sync.e2e.test.js
@@ -10,7 +10,7 @@ const RESULT_PREFIX = "__PEERSKY_RESULT__";
 const HARNESS_TIMEOUT_MS = 260_000;
 const MAX_GAP_PX = 48;
 const EXPECTED_FINAL_TEXT =
-  "first line after block by person1\nsecond line after block by person 2\nthird line after block by person 3\n\n# person3\n- line1\n- line2\n- line3\n\n# person1\n- line1\n- line2\n- line3\n\n# person2\n- line1\n- line2\n- line3";
+  "second line after block by person 2\nthird line after block by person 3\n\n# person3\n- line1\n- line2\n- line3\n\n# person1\n- line1\n- line2\n- line3\n\n# person2\n- line1\n- line2\n- line3";
 
 function createRoomServer() {
   let docContent = "";
@@ -363,18 +363,15 @@ describe("p2pmd: 3-peer gutter sync E2E (distributed edits)", function () {
       }
     }
 
-    // Semantic correctness:
-    // top lines authored by respective peers, plus each person block owner.
-    // Final text lines:
-    // 1 => person1, 2 => person2, 3 => person3
-    // 5-8 => person3, 10-13 => person1, 15-18 => person2
+    // Semantic correctness for delete + trailing-space churn scenario:
+    // line ownership should remain stable for each person block.
+    // Top lines can legitimately change owner if another peer edits them.
     const expectedOwnerByLine = new Map([
-      [1, "person1"],
+      [1, "person2"],
       [2, "person2"],
-      [3, "person3"],
-      [5, "person3"], [6, "person3"], [7, "person3"], [8, "person3"],
-      [10, "person1"], [11, "person1"], [12, "person1"], [13, "person1"],
-      [15, "person2"], [16, "person2"], [17, "person2"], [18, "person2"],
+      [4, "person3"], [5, "person3"], [6, "person3"], [7, "person3"],
+      [9, "person1"], [10, "person1"], [11, "person1"], [12, "person1"],
+      [14, "person2"], [15, "person2"], [16, "person2"], [17, "person2"],
     ]);
     for (const inst of result.instances) {
       const byLine = new Map((inst.lineOwners || []).map((line) => [line.line, line]));


### PR DESCRIPTION
## Issue 
NA

## Changes

- Added a new 3-peer p2pmd gutter ownership E2E test flow.
- Added harness actions for:
  - delete-from-top after distributed inserts
  - blank-line burst insert/remove around shared blocks
  - trailing-space add/remove on collaborative lines
- Added strict assertions for:
  - final text convergence across peers
  - cross-peer line ownership token consistency
  - block-level ownership correctness
  - gutter continuity

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran integration test:
  - `npm run test:p2pmd:gutter:e2e`
- Validated the expanded scenario passes with:
  - synchronized final document content on all 3 peers
  - consistent line ownership tokens across peers
  - expected block ownership after delete/whitespace churn

## Checklist

- [x] My code follows the contribution guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented code where needed for clarity.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.