### PR TITLE
fix: improve libp2p NAT traversal and disable built-in reprovider, and PeerChat updates

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -873,10 +873,12 @@ ipcMain.handle('check-built-in-engine', (event, template) => {
 setupP2pmdPdfExportIpc()
 
 // Suppress the libp2p/utils queue stack-overflow that fires when the
-// kad-DHT reprovider runs. Without this Electron shows a blocking dialog.
+// kad-DHT provide operation runs. The provide still succeeds via HTTP
+// delegated routing; only the DHT's internal queue overflows. Without
+// this handler Electron shows a blocking crash dialog.
 process.on('uncaughtException', (error) => {
   if (error instanceof RangeError && error.message === 'Maximum call stack size exceeded') {
-    log.warn('[main] Caught libp2p queue stack overflow (reprovider) — suppressed')
+    log.debug('[main] Suppressed libp2p DHT queue stack overflow (known issue, provide succeeds via delegated routing)')
     return
   }
   log.error('[main] Uncaught exception:', error)

--- a/src/protocols/helia/helia.js
+++ b/src/protocols/helia/helia.js
@@ -58,16 +58,18 @@ export async function createNode() {
     addresses: {
       listen: [
         '/ip4/0.0.0.0/tcp/0',
-        '/ip4/0.0.0.0/tcp/0/ws',
-        '/ip4/0.0.0.0/udp/0/webrtc-direct',
+        '/ip4/0.0.0.0/tcp/4002/ws',
+        '/ip4/0.0.0.0/udp/4003/webrtc-direct',
         '/ip6/::/tcp/0',
-        '/ip6/::/tcp/0/ws',
-        '/ip6/::/udp/0/webrtc-direct',
+        '/ip6/::/tcp/4002/ws',
+        '/ip6/::/udp/4003/webrtc-direct',
         '/p2p-circuit'
       ],
     },
     transports: [
-      circuitRelayTransport(),
+      circuitRelayTransport({
+        reservationConcurrency: 3
+      }),
       tcp(),
       webRTC(),
       webRTCDirect(),
@@ -81,19 +83,26 @@ export async function createNode() {
     ],
     services: {
       autoNAT: autoNAT(),
-      autoTLS: autoTLS(),
+      autoTLS: autoTLS({
+        autoConfirmAddress: true
+      }),
       dcutr: dcutr(),
       delegatedRouting: delegatedRoutingV1HttpApiClient({ url: 'https://delegated-ipfs.dev' }),
       dht: kadDHT({
         validators: { ipns: ipnsValidator },
         selectors: { ipns: ipnsSelector },
         clientMode: false,
+        reprovide: {
+          interval: 2147483647
+        }
       }),
       identify: identify(),
       identifyPush: identifyPush(),
       keychain: keychain(),
       ping: ping(),
-      upnp: uPnPNAT(),
+      upnp: uPnPNAT({
+        autoConfirmAddress: true
+      }),
       http: http(),
     },
     connectionManager: {


### PR DESCRIPTION
Disable the built-in kad-DHT reprovider (`interval: max-int32`) to prevent a stack overflow caused by its internal queue bug; our custom sequential reprovider in `ipfs-handler.js` handles re-providing every 6h instead. Use stable ports for WSS (4002) and WebRTC-Direct (4003), enable `autoConfirmAddress` on autoTLS and UPnP for faster public address announcement, and increase circuit relay `reservationConcurrency` to 3. The residual DHT queue overflow error is silenced (demoted to debug) since content providing succeeds via HTTP delegated routing.

Also updates PeerChat app.