### PR TITLE
ci: cache Electron binary and use npm rebuild for recovery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,14 +35,43 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/jod'
 
       - name: Non-tag specific build step
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: echo "This build was triggered without a tag."
 
+      - name: Cache Electron download
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/Library/Caches/electron
+            ~\AppData\Local\electron\Cache
+          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            electron-${{ runner.os }}-
+
       - name: Install dependencies with npm
-        run: npm ci
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          shell: bash
+          command: npm ci
+
+      - name: Ensure Electron binary
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          shell: bash
+          command: |
+            if ! node -e "require('electron')" 2>/dev/null; then
+              echo "Electron binary missing — running npm rebuild electron..."
+              npm rebuild electron
+            fi
+            node -e "console.log('Electron path:', require('electron'))"
 
       - name: Run tests
         uses: nick-fields/retry@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-15, ubuntu-latest, windows-latest]
 
     steps:
       - name: Install libarchive-tools for pacman build # Related https://github.com/electron-userland/electron-builder/issues/4181

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15]
 
     steps:
       - name: Checkout repository
@@ -24,11 +24,40 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: "lts/jod"
           cache: "npm"
 
+      - name: Cache Electron download
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/Library/Caches/electron
+            ~\AppData\Local\electron\Cache
+          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            electron-${{ runner.os }}-
+
       - name: Install dependencies
-        run: npm ci
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          shell: bash
+          command: npm ci
+
+      - name: Ensure Electron binary
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          shell: bash
+          command: |
+            if ! node -e "require('electron')" 2>/dev/null; then
+              echo "Electron binary missing — running npm rebuild electron..."
+              npm rebuild electron
+            fi
+            node -e "console.log('Electron path:', require('electron'))"
 
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
The build had been working fine for months because the Electron postinstall step (which downloads the ~150 MB binary from GitHub Releases) usually succeeds on the first try. Recently GitHub started rolling out a new `macos-latest` image (migration to macOS 26 in mid-2026), and the new image's network behavior caused that download to fail occasionally. Since the Electron binary was never cached, every CI run re-downloaded it fresh from GitHub, which gave plenty of chances for things to go wrong.